### PR TITLE
Add click effect for copy icon - the deprecated >>> replaced fix#138 fix#148

### DIFF
--- a/src/components/AccountPanel.vue
+++ b/src/components/AccountPanel.vue
@@ -121,7 +121,7 @@ export default {
   @apply text-white mb-0 font-normal;
 }
 
-.account-panel__balance h1 >>> sub {
+.account-panel__balance h1 :deep(sub) {
   @apply bottom-0 text-half;
 }
 

--- a/src/components/index/CreateModal.vue
+++ b/src/components/index/CreateModal.vue
@@ -11,13 +11,13 @@
           <span class="flex items-center">
             <span class="font-mono break-all text-sm2">{{ address }}</span>
             <button
-              class="flex-shrink-0 w-20 ml-24 text-green"
+              class="flex-shrink-0 w-20 ml-24 text-green on-clicked-effect"
               v-on:click.prevent="generateWallet"
             >
               <RefreshIcon/>
             </button>
             <button
-              class="flex-shrink-0 w-24 ml-24 text-green"
+              class="flex-shrink-0 w-24 ml-24 text-green on-clicked-effect"
               v-if="canCopy"
               @click="copyToClipboard(address)"
             >
@@ -32,7 +32,7 @@
               {{ privateKey }}
             </span>
             <button
-              class="flex-shrink-0 w-24 text-green ml-18"
+              class="flex-shrink-0 w-24 text-green ml-18 on-clicked-effect"
               v-if="canCopy"
               @click="copyToClipboard(privateKey)"
             >
@@ -199,3 +199,47 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.on-clicked-effect {
+  transition: all 0.4s ease-in;
+}
+
+.on-clicked-effect:before {
+  content: '';
+  background-color: aliceblue;
+  border-radius: 50%;
+  display: block;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  transform: scale(0.001, 0.001);
+}
+
+.on-clicked-effect:focus:not(:active) {
+  position: relative;
+  display: inline-block;
+  outline: 0;
+}
+
+.on-clicked-effect:focus:not(:active):before {
+  animation: clicked_animation 0.8s ease-out;
+}
+
+@keyframes clicked_animation {
+  50% {
+    transform: scale(1.5, 1.5);
+    opacity: 0;
+  }
+  99% {
+    transform: scale(0.001, 0.001);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(0.001, 0.001);
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/tx/DepositModal.vue
+++ b/src/components/tx/DepositModal.vue
@@ -489,11 +489,11 @@ export default {
 </script>
 
 <style scoped>
-.sub-heading >>> .amount .currency {
+.sub-heading  :deep(.amount .currency) {
   @apply ml-5;
 }
 
-.convert-info >>> .amount .currency {
+.convert-info :deep(.amount .currency) {
   @apply ml-5;
 }
 
@@ -501,7 +501,7 @@ export default {
   @apply text-white text-3xl;
 }
 
-.amount.sub >>> .currency {
+.amount.sub :deep(.currency) {
   @apply text-half bottom-0 ml-2;
 }
 

--- a/src/components/tx/SellModal.vue
+++ b/src/components/tx/SellModal.vue
@@ -506,11 +506,11 @@ export default {
 </script>
 
 <style scoped>
-.sub-heading >>> .amount .currency {
+.sub-heading :deep(.amount .currency) {
   @apply ml-5;
 }
 
-.convert-info >>> .amount .currency {
+.convert-info :deep(.amount .currency) {
   @apply ml-5;
 }
 
@@ -518,7 +518,7 @@ export default {
   @apply text-white text-3xl;
 }
 
-.amount.sub >>> .currency {
+.amount.sub :deep(.currency) {
   @apply text-half bottom-0 ml-2;
 }
 

--- a/src/components/tx/SendModal.vue
+++ b/src/components/tx/SendModal.vue
@@ -343,7 +343,7 @@ export default {
 </script>
 
 <style scoped>
-.sub-heading >>> .amount .currency {
+.sub-heading :deep(.amount .currency) {
   @apply ml-5;
 }
 
@@ -351,7 +351,7 @@ export default {
   @apply text-white text-3xl;
 }
 
-.amount.sub >>> .currency {
+.amount.sub :deep(.currency) {
   @apply text-half bottom-0 ml-2;
 }
 

--- a/src/components/tx/WithdrawModal.vue
+++ b/src/components/tx/WithdrawModal.vue
@@ -483,11 +483,11 @@ export default {
 </script>
 
 <style scoped>
-.sub-heading >>> .amount .currency {
+.sub-heading :deep(.amount .currency) {
   @apply ml-5;
 }
 
-.convert-info >>> .amount .currency {
+.convert-info :deep(.amount .currency) {
   @apply ml-5;
 }
 
@@ -495,7 +495,7 @@ export default {
   @apply text-white text-3xl;
 }
 
-.amount.sub >>> .currency {
+.amount.sub :deep(.currency) {
   @apply text-half bottom-0 ml-2;
 }
 


### PR DESCRIPTION
The style code code can be moved to index.css  if the effect will be used elsewhere in the app.