### PR TITLE
add cross-env windows node args + feat: show USD balance #169

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@vue/cli-plugin-router": "~4.5.0",
         "@vue/cli-service": "~4.5.0",
         "@vue/compiler-sfc": "^3.0.0",
+        "cross-env": "^7.0.3",
         "eslint": "^7.32.0",
         "eslint-plugin-vue": "^8.4.0",
         "lodash": "^4.17.21",
@@ -5284,6 +5285,83 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-env/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-env/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/cross-spawn": {
@@ -21364,6 +21442,58 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "lint": "eslint --ext js,vue src",
     "lint:fix": "eslint --fix --ext js,vue src",
     "start": "node server/index.js",
-    "testnet": "VUE_APP_IS_TESTNET=true VUE_APP_BLOCKCHAIN_API_URL=https://xe1.test.network VUE_APP_INDEX_API_URL=https://index.test.network VUE_APP_EXPLORER_URL=https://test.network VUE_APP_BRIDGE_WALLET_ADDRESS=xe_BEE3d7E5f007b662B2C886d51e2B3E08de090488 npm run dev",
-    "mainnet": "VUE_APP_IS_TESTNET=false VUE_APP_BLOCKCHAIN_API_URL=https://api.xe.network VUE_APP_INDEX_API_URL=https://index.xe.network VUE_APP_EXPLORER_URL=https://xe.network VUE_APP_BRIDGE_WALLET_ADDRESS=xe_A4788d8201Fb879e3b7523a0367401D2a985D42F npm run dev"
+    "testnet": "cross-env VUE_APP_IS_TESTNET=true VUE_APP_BLOCKCHAIN_API_URL=https://xe1.test.network VUE_APP_INDEX_API_URL=https://index.test.network VUE_APP_EXPLORER_URL=https://test.network VUE_APP_BRIDGE_WALLET_ADDRESS=xe_BEE3d7E5f007b662B2C886d51e2B3E08de090488 npm run dev",
+    "mainnet": "cross-env VUE_APP_IS_TESTNET=false VUE_APP_BLOCKCHAIN_API_URL=https://api.xe.network VUE_APP_INDEX_API_URL=https://index.xe.network VUE_APP_EXPLORER_URL=https://xe.network VUE_APP_BRIDGE_WALLET_ADDRESS=xe_A4788d8201Fb879e3b7523a0367401D2a985D42F npm run dev"
   },
   "main": "server/index.js",
   "dependencies": {
@@ -63,6 +63,7 @@
     "@vue/cli-plugin-router": "~4.5.0",
     "@vue/cli-service": "~4.5.0",
     "@vue/compiler-sfc": "^3.0.0",
+    "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
     "eslint-plugin-vue": "^8.4.0",
     "lodash": "^4.17.21",

--- a/src/components/AccountPanel.vue
+++ b/src/components/AccountPanel.vue
@@ -11,7 +11,7 @@
         <div class="account-panel__balance">
           <h3 class="mb-1">Balance</h3>
           <h1><Amount :value="balance / 1e6" currency="XE" sub/></h1>
-          <h2><Amount :value="balanceInUsd" currency="USD" /></h2>
+          <h2><Amount :value="balanceInUsd" currency="USD" :maxFractDigits="2" /></h2>
         </div>
       </div>
 

--- a/src/components/AccountPanel.vue
+++ b/src/components/AccountPanel.vue
@@ -11,7 +11,7 @@
         <div class="account-panel__balance">
           <h3 class="mb-1">Balance</h3>
           <h1><Amount :value="balance / 1e6" currency="XE" sub/></h1>
-          <h2><Amount :value="balanceInUsd" currency="USD" :decimalPlaces="2"/></h2>
+          <h2><Amount :value="usdBalance" currency="USD" :decimalPlaces="2"/></h2>
         </div>
       </div>
 
@@ -57,7 +57,6 @@ import ExchangeModal from './tx/ExchangeModal'
 import SellModal from './tx/SellModal'
 import SendModal from './tx/SendModal'
 import WithdrawModal from './tx/WithdrawModal'
-import { fetchTokenValue } from '../utils/api'
 import { mapState } from 'vuex'
 import { ArrowUpIcon, SwitchHorizontalIcon } from '@heroicons/vue/outline'
 
@@ -73,15 +72,11 @@ export default {
     SwitchHorizontalIcon,
     WithdrawModal
   },
-  computed: mapState(['address', 'balance']),
+  computed: mapState(['address', 'balance', 'usdBalance']),
   data() {
     return {
-      modal: '',
-      balanceInUsd: 0
+      modal: ''
     }
-  },
-  mounted () {
-    this.setTokenValue()
   },
   methods: {
     reset() {
@@ -101,10 +96,6 @@ export default {
     },
     openWithdraw() {
       this.modal = 'withdraw'
-    },
-    async setTokenValue() {
-      const { usdPerXE } = await fetchTokenValue()
-      this.balanceInUsd = usdPerXE * (this.balance / 1e6)
     }
   }
 }

--- a/src/components/AccountPanel.vue
+++ b/src/components/AccountPanel.vue
@@ -11,7 +11,7 @@
         <div class="account-panel__balance">
           <h3 class="mb-1">Balance</h3>
           <h1><Amount :value="balance / 1e6" currency="XE" sub/></h1>
-          <h2><Amount :value="balanceInUsd" currency="USD" :maxFractDigits="2" /></h2>
+          <h2><Amount :value="balanceInUsd" currency="USD" :decimalPlaces="2"/></h2>
         </div>
       </div>
 

--- a/src/components/AccountPanel.vue
+++ b/src/components/AccountPanel.vue
@@ -11,6 +11,7 @@
         <div class="account-panel__balance">
           <h3 class="mb-1">Balance</h3>
           <h1><Amount :value="balance / 1e6" currency="XE" sub/></h1>
+          <h2><Amount :value="balanceInUsd" currency="USD" /></h2>
         </div>
       </div>
 
@@ -56,6 +57,7 @@ import ExchangeModal from './tx/ExchangeModal'
 import SellModal from './tx/SellModal'
 import SendModal from './tx/SendModal'
 import WithdrawModal from './tx/WithdrawModal'
+import { fetchTokenValue } from '../utils/api'
 import { mapState } from 'vuex'
 import { ArrowUpIcon, SwitchHorizontalIcon } from '@heroicons/vue/outline'
 
@@ -74,8 +76,12 @@ export default {
   computed: mapState(['address', 'balance']),
   data() {
     return {
-      modal: ''
+      modal: '',
+      balanceInUsd: 0
     }
+  },
+  mounted () {
+    this.setTokenValue()
   },
   methods: {
     reset() {
@@ -95,6 +101,10 @@ export default {
     },
     openWithdraw() {
       this.modal = 'withdraw'
+    },
+    async setTokenValue() {
+      const { usdPerXE } = await fetchTokenValue()
+      this.balanceInUsd = usdPerXE * (this.balance / 1e6)
     }
   }
 }
@@ -121,6 +131,10 @@ export default {
 
 .account-panel__balance h3 {
   @apply text-green mb-5;
+}
+
+.account-panel__balance h2 {
+  @apply text-gray-300 text-md mb-0;
 }
 
 .account-panel__balance h1 {

--- a/src/components/Amount.vue
+++ b/src/components/Amount.vue
@@ -16,7 +16,8 @@ export default {
     currency: String,
     short: Boolean,
     sub: Boolean,
-    value: [Number, String]
+    value: [Number, String],
+    maxFractDigits: Number
   },
   computed: {
     isXE() {
@@ -30,7 +31,7 @@ export default {
       if (this.isXE && !this.short) {
         return xeStringFromMicroXe(this.value * 1e6, true)
       }
-      return this.value.toLocaleString('en-US', { maximumFractionDigits: 6 })
+      return this.value.toLocaleString('en-US', { maximumFractionDigits: this.maxFractDigits || 6 })
     }
   }
 }

--- a/src/components/Amount.vue
+++ b/src/components/Amount.vue
@@ -14,10 +14,10 @@ export default {
   name: 'Amount',
   props: {
     currency: String,
+    decimalPlaces: Number,
     short: Boolean,
     sub: Boolean,
-    value: [Number, String],
-    maxFractDigits: Number
+    value: [Number, String]
   },
   computed: {
     isXE() {
@@ -31,7 +31,7 @@ export default {
       if (this.isXE && !this.short) {
         return xeStringFromMicroXe(this.value * 1e6, true)
       }
-      return this.value.toLocaleString('en-US', { maximumFractionDigits: this.maxFractDigits || 6 })
+      return this.value.toLocaleString('en-US', { maximumFractionDigits: this.decimalPlaces || 6 })
     }
   }
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -154,11 +154,14 @@ const formatTransactions = (address, data, pending) => {
   return transactions
 }
 
+const fetchTokenValue = async () => fetchData(`${INDEX_API_URL}/token/current`)
+
 export {
   fetchBlocks,
   fetchPendingTransactions,
   fetchGasRates,
   fetchExchangeRates,
   fetchTransactions,
-  formatTransactions
+  formatTransactions,
+  fetchTokenValue
 }


### PR DESCRIPTION
**chore: add cross-env - pass node args on windows**
I'm using Windows and can't run `npm run testnet` `npm run mainnet` without using cross-env to pass node args.

**feat: new USD value of balance - #169**
Show usd balance of XE value

![image](https://user-images.githubusercontent.com/49697006/152657015-1d6b433c-a37f-42b2-bf57-406ac724a27f.png)
