### PR TITLE
fix: break private key into 2x32 char lines

### DIFF
--- a/src/components/index/CreateModal.vue
+++ b/src/components/index/CreateModal.vue
@@ -28,7 +28,7 @@
         <div class="form-group mb-25">
           <label>PRIVATE KEY</label>
           <span class="flex items-center">
-            <span class="font-mono break-all text-sm2">
+            <span class="private-key font-mono break-all text-sm2">
               {{ privateKey }}
             </span>
             <button
@@ -203,6 +203,10 @@ export default {
 </script>
 
 <style scoped>
+.private-key {
+  width: 32ch
+}
+
 .on-clicked-effect {
   transition: all 0.4s ease-in;
 }


### PR DESCRIPTION
I used `width: 32ch`, but if you prefer I can change to `230px` which is the same width. Not sure how well supported `ch` is across browsers, but from what I read it's supported in all major browsers. 