### PR TITLE
fix: allow user to release unlocked stakes

### DIFF
--- a/src/components/stakes/CreateStakeModal.vue
+++ b/src/components/stakes/CreateStakeModal.vue
@@ -85,7 +85,7 @@
               :disabled="!canCreate"
               @click="create"
               class="w-full button button--success"
-            >Create stake</button>
+            >Create Stake</button>
           </div>
           <!-- eslint-disable-next-line max-len -->
           <div v-if="submitError" class="px-20 py-20 my-20 text-center bg-black border border-gray-700 rounded convert-info md:text-left border-opacity-30 border-color">

--- a/src/components/stakes/ReleaseStakeModal.vue
+++ b/src/components/stakes/ReleaseStakeModal.vue
@@ -77,14 +77,14 @@
               @click="release"
               class="w-full button button--success"
             >
-              Release stake
+              Release Stake
             </button>
             <button
               v-else
               @click="readyExpressRelease"
               class="w-full button button--success"
             >
-              Express release
+              Express Release
             </button>
           </div>
           <!-- eslint-disable-next-line max-len -->
@@ -164,7 +164,7 @@
               :disabled="!canRelease"
               @click="release"
               class="w-full button button--success"
-            >Release stake</button>
+            >Release Stake</button>
           </div>
           <!-- eslint-disable-next-line max-len -->
           <div v-if="submitError" class="px-20 py-20 my-20 text-center bg-black border border-gray-700 rounded convert-info md:text-left border-opacity-30 border-color">
@@ -409,8 +409,7 @@ export default {
     },
     async release() {
       this.passwordError = ''
-
-      if (!await this.v$.$validate()) return
+      if (!this.canRelease) return
       if (!await this.checkPassword()) return
       const privateKey = await storage.getPrivateKey(this.password)
 

--- a/src/components/stakes/UnlockStakeModal.vue
+++ b/src/components/stakes/UnlockStakeModal.vue
@@ -67,7 +67,7 @@
               :disabled="!canUnlock"
               @click="unlock"
               class="w-full button button--success"
-            >Unlock stake</button>
+            >Unlock Stake</button>
           </div>
           <!-- eslint-disable-next-line max-len -->
           <div v-if="submitError" class="px-20 py-20 my-20 text-center bg-black border border-gray-700 rounded convert-info md:text-left border-opacity-30 border-color">


### PR DESCRIPTION
Releasing unlocked stakes should now work. 
The problem before was that the `release()` function was checking `v$.$validate()`, but this includes the `confirmPhrase` which isn't used for normal release. 
I used the already created `canRelease` computed prop which checks the full validation or just the password depending on whether the stake is unlocked. 
I don't know if there is a difference between `v$.$validate()` and just checking `v$.$invalid`, but it seems to do the trick!