### PR TITLE
fix: display correct number of cols when no stakes

### DIFF
--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -9,7 +9,7 @@
         <th width="8%">Type</th>
         <th width="8%">Status</th>
         <th class="amount-col" width="10%">Amount XE</th>
-        <th width="10%">&nbsp;</th>
+        <th width="10%" v-if="stakes.length">&nbsp;</th>
       </tr>
       <tr v-else>
         <th width="19%">ID</th>
@@ -18,7 +18,7 @@
         <th width="8%">Type</th>
         <th width="8%">Status</th>
         <th class="amount-col" width="10%">Amount XE</th>
-        <th width="10%">&nbsp;</th>
+        <th width="10%" v-if="stakes.length">&nbsp;</th>
       </tr>
     </thead>
     <tbody v-if="stakes.length">


### PR DESCRIPTION
rather than expanding the col-span to 8, I hide the blank action column when no stakes available. I feel it makes more sense to have that column hidden since it has no column header