### PR TITLE
Issue/193 hash link component

### DIFF
--- a/src/components/HashLink.vue
+++ b/src/components/HashLink.vue
@@ -54,7 +54,7 @@ export default {
       switch (this.to) {
       case 'explorer':
         return `${explorerUrl}/${this.hashType}/${this.hash}`
-      case 'ethernet':
+      case 'etherscan':
         return `${etherscanUrls[this.chainId]}/tx/${this.hash}`
       default:
         return ''

--- a/src/components/HashLink.vue
+++ b/src/components/HashLink.vue
@@ -15,10 +15,18 @@
 <script>
 /*global process*/
 
+const explorerUrl = process.env.VUE_APP_EXPLORER_URL
+
+const etherscanUrls = {
+  '0x1': 'https://etherscan.io',
+  '0x4': 'https://rinkeby.etherscan.io'
+}
+
 export default {
   // eslint-disable-next-line vue/multi-word-component-names
   name: 'HashLink',
   props: {
+    chainId: String,
     stake: String,
     to: String,
     transaction: String,
@@ -27,7 +35,7 @@ export default {
   },
   computed: {
     hash() {
-      return this.transaction || this.stake || this.wallet
+      return this.transaction || this.stake || this.wallet || null
     },
     shortHash() {
       if (this.hash === null) return ''
@@ -36,15 +44,21 @@ export default {
         this.hash.substring(this.hash.length - 4)
       ].join('...')
     },
-    type() {
+    hashType() {
       if (this.transaction) return 'transaction'
       else if (this.stake) return 'stake'
       else if (this.wallet) return 'wallet'
       else return ''
     },
     url() {
-      const baseUrl = this.to === 'explorer' ? process.env.VUE_APP_EXPLORER_URL : null
-      return `${baseUrl}/${this.type}/${this.hash}`
+      switch (this.to) {
+      case 'explorer':
+        return `${explorerUrl}/${this.hashType}/${this.hash}`
+      case 'ethernet':
+        return `${etherscanUrls[this.chainId]}/tx/${this.hash}`
+      default:
+        return ''
+      }
     }
   }
 }

--- a/src/components/HashLink.vue
+++ b/src/components/HashLink.vue
@@ -41,7 +41,7 @@ export default {
     },
     hashType() {
       if (this.transaction) {
-        return this.to === 'explorer' ? 'tranasction' : 'tx'
+        return this.to === 'explorer' ? 'transaction' : 'tx'
       }
       if (this.wallet) {
         return this.to === 'explorer' ? 'wallet' : 'address'

--- a/src/components/HashLink.vue
+++ b/src/components/HashLink.vue
@@ -16,17 +16,12 @@
 /*global process*/
 
 const explorerUrl = process.env.VUE_APP_EXPLORER_URL
-
-const etherscanUrls = {
-  '0x1': 'https://etherscan.io',
-  '0x4': 'https://rinkeby.etherscan.io'
-}
+const etherscanUrl = process.env.VUE_APP_IS_TESTNET ? 'https://rinkeby.etherscan.io' : 'https://etherscan.io'
 
 export default {
   // eslint-disable-next-line vue/multi-word-component-names
   name: 'HashLink',
   props: {
-    chainId: String,
     stake: String,
     to: String,
     transaction: String,
@@ -45,17 +40,23 @@ export default {
       ].join('...')
     },
     hashType() {
-      if (this.transaction) return 'transaction'
-      else if (this.stake) return 'stake'
-      else if (this.wallet) return 'wallet'
-      else return ''
+      if (this.transaction) {
+        return this.to === 'explorer' ? 'tranasction' : 'tx'
+      }
+      if (this.wallet) {
+        return this.to === 'explorer' ? 'wallet' : 'address'
+      }
+      if (this.stake) {
+        return this.to === 'explorer' ? 'stake' : null
+      }
+      return null
     },
     url() {
       switch (this.to) {
       case 'explorer':
         return `${explorerUrl}/${this.hashType}/${this.hash}`
       case 'etherscan':
-        return `${etherscanUrls[this.chainId]}/tx/${this.hash}`
+        return `${etherscanUrl}/${this.hashType}/${this.hash}`
       default:
         return ''
       }

--- a/src/components/HashLink.vue
+++ b/src/components/HashLink.vue
@@ -1,0 +1,51 @@
+<template>
+  <span class="flex w-full overflow-hidden text-white overflow-ellipsis">
+    <a
+      class="text-lg text-white underline w-max-full overflow-hidden overflow-ellipsis"
+      :href="url"
+      target="_blank"
+    >
+      {{ truncated ? shortHash : hash }}
+    </a>
+    <!-- eslint-disable-next-line max-len -->
+    <svg class="w-20 h-20 mt-2 ml-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
+  </span>
+</template>
+
+<script>
+/*global process*/
+
+export default {
+  // eslint-disable-next-line vue/multi-word-component-names
+  name: 'HashLink',
+  props: {
+    stake: String,
+    to: String,
+    transaction: String,
+    truncated: Boolean,
+    wallet: String
+  },
+  computed: {
+    hash() {
+      return this.transaction || this.stake || this.wallet
+    },
+    shortHash() {
+      if (this.hash === null) return ''
+      return [
+        this.hash.substring(0, 6),
+        this.hash.substring(this.hash.length - 4)
+      ].join('...')
+    },
+    type() {
+      if (this.transaction) return 'transaction'
+      else if (this.stake) return 'stake'
+      else if (this.wallet) return 'wallet'
+      else return ''
+    },
+    url() {
+      const baseUrl = this.to === 'explorer' ? process.env.VUE_APP_EXPLORER_URL : null
+      return `${baseUrl}/${this.type}/${this.hash}`
+    }
+  }
+}
+</script>

--- a/src/components/stakes/CreateStakeModal.vue
+++ b/src/components/stakes/CreateStakeModal.vue
@@ -127,17 +127,7 @@
           </div>
           <div class="form-group mb-14">
             <label>Transaction hash</label>
-            <span class="flex w-full overflow-hidden text-white overflow-ellipsis">
-              <a
-                class="text-lg text-white underline"
-                :href="`${explorerUrl}/transaction/${completedTx.hash}`"
-                target="_blank"
-              >
-                {{ completedTxShortHash }}
-              </a>
-              <!-- eslint-disable-next-line max-len -->
-              <svg class="w-20 h-20 mt-2 ml-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
-            </span>
+            <HashLink to="explorer" :transaction="completedTx.hash" truncated />
           </div>
           <div class="flex items-center mt-24 leading-8 text-gray">
             <!-- eslint-disable-next-line max-len -->
@@ -165,6 +155,7 @@ import * as storage from '../../utils/storage'
 import * as validation from '../../utils/validation'
 import * as xe from '@edge/xe-utils'
 import Amount from '../Amount'
+import HashLink from '../HashLink'
 import { LockOpenIcon } from '@heroicons/vue/outline'
 import Modal from '../Modal'
 import Radio from '../Radio'
@@ -175,6 +166,7 @@ export default {
   name: 'CreateStakeModal',
   components: {
     Amount,
+    HashLink,
     LockOpenIcon,
     Modal,
     Radio
@@ -213,16 +205,6 @@ export default {
     },
     canCreate() {
       return !this.v$.$invalid
-    },
-    completedTxShortHash() {
-      if (this.completedTx === null) return ''
-      return [
-        this.completedTx.hash.substring(0, 6),
-        this.completedTx.hash.substring(this.completedTx.hash.length - 4)
-      ].join('...')
-    },
-    explorerUrl() {
-      return process.env.VUE_APP_EXPLORER_URL
     },
     remainingBalance() {
       return (this.balance - this.stakeAmount) / 1e6

--- a/src/components/stakes/ReleaseStakeModal.vue
+++ b/src/components/stakes/ReleaseStakeModal.vue
@@ -9,17 +9,7 @@
         <div class="pb-14">
           <div class="form-group mb-14">
             <label>Stake ID</label>
-            <span class="flex w-full overflow-hidden text-white overflow-ellipsis">
-              <a
-                class="text-lg text-white underline"
-                :href="explorerStakeUrl"
-                target="_blank"
-              >
-                {{ stakeShortId }}
-              </a>
-              <!-- eslint-disable-next-line max-len -->
-              <svg class="w-20 h-20 mt-2 ml-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
-            </span>
+            <HashLink to="explorer" :stake="stake.id" truncated />
           </div>
           <div class="form-group mb-25">
             <label class="label">Stake Type</label>
@@ -206,17 +196,7 @@
           </div>
           <div class="form-group mb-14">
             <label>Transaction hash</label>
-            <span class="flex w-full overflow-hidden text-white overflow-ellipsis">
-              <a
-                class="text-lg text-white underline"
-                :href="explorerTxUrl"
-                target="_blank"
-              >
-                {{ completedTxShortHash }}
-              </a>
-              <!-- eslint-disable-next-line max-len -->
-              <svg class="w-20 h-20 mt-2 ml-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
-            </span>
+            <HashLink to="explorer" :transaction="completedTx.hash" truncated />
           </div>
           <div class="flex items-center mt-24 leading-8 text-gray">
             <!-- eslint-disable-next-line max-len -->
@@ -243,6 +223,7 @@ import * as storage from '../../utils/storage'
 import * as validation from '../../utils/validation'
 import * as xe from '@edge/xe-utils'
 import Amount from '../Amount'
+import HashLink from '../HashLink'
 import { LockOpenIcon } from '@heroicons/vue/outline'
 import Modal from '../Modal'
 import { helpers } from '@vuelidate/validators'
@@ -253,6 +234,7 @@ export default {
   name: 'ReleaseStakeModal',
   components: {
     Amount,
+    HashLink,
     LockOpenIcon,
     Modal
   },
@@ -296,22 +278,9 @@ export default {
       if (this.isUnlocked) return !this.v$.password.$invalid
       else return !this.v$.$invalid
     },
-    completedTxShortHash() {
-      if (this.completedTx === null) return ''
-      return [
-        this.completedTx.hash.substring(0, 6),
-        this.completedTx.hash.substring(this.completedTx.hash.length - 4)
-      ].join('...')
-    },
     phrase() {
       if (this.vars === null) return ''
       return `I confirm I am willing to burn ${this.vars.stake_express_release_fee * 100}% to release early`
-    },
-    explorerStakeUrl() {
-      return `${process.env.VUE_APP_EXPLORER_URL}/stake/${this.stake.id}`
-    },
-    explorerTxUrl() {
-      return `${process.env.VUE_APP_EXPLORER_URL}/transaction/${this.completedTx.hash}`
     },
     isUnlocked() {
       return this.unlocksAt < Date.now()
@@ -328,13 +297,6 @@ export default {
     },
     stakeAmountParsed() {
       return this.stake.amount / 1e6
-    },
-    stakeShortId() {
-      if (this.stake === null) return ''
-      return [
-        this.stake.id.substring(0, 6),
-        this.stake.id.substring(this.stake.id.length - 4)
-      ].join('...')
     },
     stakeTypeFormatted() {
       return this.stake.type[0].toUpperCase() + this.stake.type.slice(1)

--- a/src/components/stakes/UnlockStakeModal.vue
+++ b/src/components/stakes/UnlockStakeModal.vue
@@ -9,17 +9,7 @@
         <div class="pb-14">
           <div class="form-group mb-14">
             <label>Stake ID</label>
-            <span class="flex w-full overflow-hidden text-white overflow-ellipsis">
-              <a
-                class="text-lg text-white underline"
-                :href="explorerStakeUrl"
-                target="_blank"
-              >
-                {{ stakeShortId }}
-              </a>
-              <!-- eslint-disable-next-line max-len -->
-              <svg class="w-20 h-20 mt-2 ml-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
-            </span>
+            <HashLink to="explorer" :stake="stake.id" truncated />
           </div>
           <div class="form-group mb-25">
             <label class="label">Stake Type</label>
@@ -105,17 +95,7 @@
           </div>
           <div class="form-group mb-14">
             <label>Transaction hash</label>
-            <span class="flex w-full overflow-hidden text-white overflow-ellipsis">
-              <a
-                class="text-lg text-white underline"
-                :href="explorerTxUrl"
-                target="_blank"
-              >
-                {{ completedTxShortHash }}
-              </a>
-              <!-- eslint-disable-next-line max-len -->
-              <svg class="w-20 h-20 mt-2 ml-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
-            </span>
+            <HashLink to="explorer" :transaction="completedTx.hash" truncated />
           </div>
           <div class="flex items-center mt-24 leading-8 text-gray">
             <!-- eslint-disable-next-line max-len -->
@@ -143,6 +123,7 @@ import * as storage from '../../utils/storage'
 import * as validation from '../../utils/validation'
 import * as xe from '@edge/xe-utils'
 import Amount from '../Amount'
+import HashLink from '../HashLink'
 import { LockOpenIcon } from '@heroicons/vue/outline'
 import Modal from '../Modal'
 import { mapState } from 'vuex'
@@ -152,6 +133,7 @@ export default {
   name: 'UnlockStakeModal',
   components: {
     Amount,
+    HashLink,
     LockOpenIcon,
     Modal
   },
@@ -187,12 +169,6 @@ export default {
         this.completedTx.hash.substring(0, 6),
         this.completedTx.hash.substring(this.completedTx.hash.length - 4)
       ].join('...')
-    },
-    explorerStakeUrl() {
-      return `${process.env.VUE_APP_EXPLORER_URL}/stake/${this.stake.id}`
-    },
-    explorerTxUrl() {
-      return `${process.env.VUE_APP_EXPLORER_URL}/transaction/${this.completedTx.hash}`
     },
     stakeAmountParsed() {
       return this.stake.amount / 1e6

--- a/src/components/tx/DepositModal.vue
+++ b/src/components/tx/DepositModal.vue
@@ -202,11 +202,7 @@
 
           <div class="form-group mb-14">
             <label>Transaction hash</label>
-            <span class="flex w-full overflow-hidden text-white overflow-ellipsis">
-              <a class="text-lg text-white underline" :href="ethTxUrl" target="_blank">{{ethTxShortHash}}</a>
-              <!-- eslint-disable-next-line max-len -->
-              <svg class="w-20 h-20 mt-2 ml-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
-            </span>
+            <HashLink to="etherscan" :transaction="completedTx.hash" :chainId="chainId" truncated />
           </div>
 
           <div class="flex items-center mt-24 leading-8 text-gray">
@@ -229,6 +225,7 @@
 import * as storage from '../../utils/storage'
 import * as validation from '../../utils/validation'
 import Amount from '../Amount'
+import HashLink from '../HashLink'
 import { InformationCircleIcon } from '@heroicons/vue/solid'
 import MetaMaskOnboarding from '@metamask/onboarding'
 import Modal from '../Modal'
@@ -268,6 +265,7 @@ export default {
     Amount,
     ArrowDownIcon,
     ArrowRightIcon,
+    HashLink,
     InformationCircleIcon,
     Modal,
     Radio,

--- a/src/components/tx/DepositModal.vue
+++ b/src/components/tx/DepositModal.vue
@@ -44,19 +44,14 @@
         </div>
       </template>
       <template v-slot:body>
-        <div class="pb-14 min-h-410">
-          <div class="form-group">
+        <div>
+          <div class="form-group mb-30">
             <span class="label">Depositing from</span>
-            <div class="relative input-wrap">
-              <!-- eslint-disable-next-line max-len -->
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis">{{ ethAddress }}</span>
-            </div>
+            <HashLink to="etherscan" :wallet="ethAddress" />
           </div>
-          <div class="form-group">
+          <div class="form-group mb-30">
             <span class="label">Depositing to</span>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis">{{ address }}</span>
-            </div>
+            <HashLink to="etherscan" :wallet="address" />
           </div>
           <div class="lg-input-group" :class="{'form-group__error': v$.amount.$error}">
             <label for="key">AMOUNT</label>
@@ -77,7 +72,7 @@
             <Radio name="currency" id="max" label="MAX" @click="setAmountAsPercent(100);" />
           </div>
 
-          <div class="form-group">
+          <div class="form-group mb-14">
             <label class="flex items-center space-x-3">
               Transaction fee
               <!-- eslint-disable-next-line max-len -->
@@ -162,7 +157,7 @@
         <h2 class="mb-8">Deposit accepted<span class="testnet-header" v-if="isTestnet">(Testnet)</span></h2>
       </template>
       <template v-slot:body>
-        <div class="pb-14 min-h-410">
+        <div>
           <div class="form-group mb-14">
             <label>You are depositing</label>
             <Amount :value="amountParsed" currency="EDGE" sub/>
@@ -170,20 +165,12 @@
 
           <div class="form-group mb-14">
             <label>From</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ completedTx.from }}
-              </span>
-            </div>
+            <HashLink to="etherscan" :wallet="completedTx.from" />
           </div>
 
           <div class="form-group mb-14">
             <label>To</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ address }}
-              </span>
-            </div>
+            <HashLink to="explorer" :wallet="address" />
           </div>
 
           <div class="form-group mb-14">
@@ -202,7 +189,7 @@
 
           <div class="form-group mb-14">
             <label>Transaction hash</label>
-            <HashLink to="etherscan" :transaction="completedTx.hash" :chainId="chainId" truncated />
+            <HashLink to="etherscan" :transaction="completedTx.hash" truncated />
           </div>
 
           <div class="flex items-center mt-24 leading-8 text-gray">

--- a/src/components/tx/SellModal.vue
+++ b/src/components/tx/SellModal.vue
@@ -273,6 +273,11 @@
             <Amount :value="usdcAmountOnSubmit" currency="USDC" sub/>
           </div>
 
+          <div class="form-group mb-14">
+            <label>Transaction hash</label>
+            <HashLink to="explorer" :transaction="completedTx.hash" truncated />
+          </div>
+
           <div class="flex items-center mt-24 leading-8 text-gray">
             <!-- eslint-disable-next-line max-len -->
             <p class="mb-0">Your request has been accepted and should be processed soon. If your request cannot be processed for any reason, your XE will be returned.</p>
@@ -299,6 +304,7 @@ import * as storage from '../../utils/storage'
 import * as validation from '../../utils/validation'
 import * as xe from '@edge/xe-utils'
 import Amount from '../Amount'
+import HashLink from '../HashLink'
 import { InformationCircleIcon } from '@heroicons/vue/solid'
 import Modal from '../Modal'
 import Tooltip from '../Tooltip'
@@ -319,6 +325,7 @@ export default {
     Amount,
     ArrowDownIcon,
     ArrowRightIcon,
+    HashLink,
     InformationCircleIcon,
     LockOpenIcon,
     Modal,

--- a/src/components/tx/SellModal.vue
+++ b/src/components/tx/SellModal.vue
@@ -130,20 +130,12 @@
 
           <div class="form-group mb-14">
             <label class="label">From</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ address }}
-              </span>
-            </div>
+            <HashLink to="explorer" :wallet="address" />
           </div>
 
           <div class="form-group mb-14">
             <label class="label">To</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ recipient }}
-              </span>
-            </div>
+            <HashLink to="etherscan" :wallet="recipient" />
           </div>
 
           <div class="form-group mb-14">
@@ -242,20 +234,12 @@
 
           <div class="form-group mb-14">
             <label>From</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ address }}
-              </span>
-            </div>
+            <HashLink to="explorer" :wallet="address" />
           </div>
 
           <div class="form-group mb-14">
             <label>To</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ completedTx.data.destination }}
-              </span>
-            </div>
+            <HashLink to="etherscan" :wallet="completedTx.data.destination" />
           </div>
 
           <div class="form-group mb-14">

--- a/src/components/tx/SendModal.vue
+++ b/src/components/tx/SendModal.vue
@@ -156,17 +156,21 @@
             <label class="label">Memo</label>
             <span class="break-all">{{ completedTx.data.memo || 'None' }}</span>
           </div>
-          <div class="mb-16 form-group">
+          <div class="mb-14 form-group">
             <label>Amount</label>
             <Amount :value="completedTx.amount / 1e6" currency="XE" short sub/>
           </div>
-          <div class="mb-16 form-group">
+          <div class="mb-14 form-group">
             <label>Fee</label>
             <Amount :value="0" currency="XE" short sub/>
           </div>
-          <div class="mb-0 form-group">
+          <div class="mb-14 form-group">
             <label>Recipient receives</label>
             <Amount :value="completedTx.amount / 1e6" currency="XE" short sub/>
+          </div>
+          <div class="form-group mb-14">
+            <label>Transaction hash</label>
+            <HashLink to="explorer" :transaction="completedTx.hash" truncated />
           </div>
         </div>
       </template>
@@ -190,6 +194,7 @@ import * as storage from '../../utils/storage'
 import * as validation from '../../utils/validation'
 import * as xe from '@edge/xe-utils'
 import Amount from '../Amount'
+import HashLink from '../HashLink'
 import { LockOpenIcon } from '@heroicons/vue/outline'
 import Logo from '../Logo'
 import Modal from '../Modal'
@@ -206,6 +211,7 @@ export default {
   name: 'SendModal',
   components: {
     Amount,
+    HashLink,
     LockOpenIcon,
     Logo,
     Modal,

--- a/src/components/tx/SendModal.vue
+++ b/src/components/tx/SendModal.vue
@@ -71,11 +71,11 @@
       </template>
       <template v-slot:body>
         <div class="pb-14 min-h-410">
-          <div class="form-group mb-25">
+          <div class="form-group mb-14">
             <label class="label">Send to</label>
-            <span class="break-all">{{ recipient }}</span>
+            <HashLink to="explorer" :wallet="recipient" />
           </div>
-          <div class="form-group mb-25">
+          <div class="form-group mb-14 text-xl">
             <label class="label">Memo</label>
             <span class="break-all">{{ memo || 'None' }}</span>
           </div>
@@ -148,11 +148,11 @@
           <div class="pb-4 mb-20 border-b border-gray-700 decor-block border-opacity-30">
             <!-- <CheckIcon class="w-52 text-green"/> -->
           </div>
-          <div class="form-group mb-25">
+          <div class="form-group mb-14">
             <label class="label">Recipient</label>
-            <span class="break-all">{{ completedTx.recipient }}</span>
+            <HashLink to="explorer" :wallet="completedTx.recipient" />
           </div>
-          <div class="form-group mb-25">
+          <div class="form-group mb-14 text-xl">
             <label class="label">Memo</label>
             <span class="break-all">{{ completedTx.data.memo || 'None' }}</span>
           </div>

--- a/src/components/tx/WithdrawModal.vue
+++ b/src/components/tx/WithdrawModal.vue
@@ -251,6 +251,11 @@
             <Amount :value="edgeAmountOnSubmit" currency="EDGE" sub/>
           </div>
 
+          <div class="form-group mb-14">
+            <label>Transaction hash</label>
+            <HashLink to="explorer" :transaction="completedTx.hash" truncated />
+          </div>
+
           <div class="flex items-center mt-24 leading-8 text-gray">
             <p class="mb-0">Your request has been accepted and should be processed within 24 hours.</p>
           </div>
@@ -274,6 +279,7 @@ import * as storage from '../../utils/storage'
 import * as validation from '../../utils/validation'
 import * as xe from '@edge/xe-utils'
 import Amount from '../Amount'
+import HashLink from '../HashLink'
 import { InformationCircleIcon } from '@heroicons/vue/solid'
 import Modal from '../Modal'
 import Tooltip from '../Tooltip'
@@ -292,6 +298,7 @@ export default {
     Amount,
     ArrowDownIcon,
     ArrowRightIcon,
+    HashLink,
     InformationCircleIcon,
     LockOpenIcon,
     Modal,

--- a/src/components/tx/WithdrawModal.vue
+++ b/src/components/tx/WithdrawModal.vue
@@ -128,20 +128,12 @@
 
           <div class="form-group mb-14">
             <label class="label">From</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ address }}
-              </span>
-            </div>
+            <HashLink to="explorer" :wallet="address" />
           </div>
 
           <div class="form-group mb-14">
             <label class="label">To</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ recipient }}
-              </span>
-            </div>
+            <HashLink to="etherscan" :wallet="recipient" />
           </div>
 
           <div class="form-group mb-14">
@@ -225,20 +217,12 @@
 
           <div class="form-group mb-14">
             <label>From</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ address }}
-              </span>
-            </div>
+            <HashLink to="explorer" :wallet="address" />
           </div>
 
           <div class="form-group mb-14">
             <label>To</label>
-            <div class="relative input-wrap">
-              <span class="block w-full overflow-hidden text-white input-filled overflow-ellipsis text-caption">
-                {{ completedTx.data.destination }}
-              </span>
-            </div>
+            <HashLink to="etherscan" :wallet="completedTx.data.destination" />
           </div>
 
           <div class="form-group mb-14">


### PR DESCRIPTION
Created HashLink component and changed all hashes (stake Id/tx hash/wallet address) in all modals to use the new component

I truncated the stake ID and tx hashes in the middle as these were truncated this way originally, but left the wallet addresses in full. These do have `overflow: ellipsis` applied anyway so any overflow will still be truncated by css

Have tested every link in all modals and they seem to be working correctly. 