### PR TITLE
Issue/174 stake table sorting fixes

### DIFF
--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -102,8 +102,7 @@ export default {
   computed: {
     ...mapState(['address']),
     sortQuery() {
-      if (this.$route.query.sort) return this.$route.query.sort
-      else return '-created'
+      return this.$route.query.sort
     }
   },
   mounted() {
@@ -119,13 +118,15 @@ export default {
   methods: {
     async updateStakes() {
       this.loading = true
+      // the sort query sent to index needs to include "-created", but this is hidden from user in browser url
+      const sortQuery = this.$route.query.sort ? this.$route.query.sort + ',-created' : '-created'
       const stakes = await index.stake.stakes(
         process.env.VUE_APP_INDEX_API_URL,
         this.address,
         {
           limit: this.limit,
           page: this.page,
-          sort: this.sortQuery
+          sort: sortQuery
         }
       )
       this.stakes = stakes.results
@@ -133,7 +134,9 @@ export default {
       this.loading = false
     },
     updateSorting(newSortQuery) {
-      this.$router.replace({ name: 'Staking', query: { ...this.$route.query, sort: newSortQuery } })
+      const query = { ...this.$route.query, sort: newSortQuery }
+      if (!newSortQuery) delete query.sort
+      this.$router.replace({ query })
     }
   },
   watch: {

--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -119,7 +119,7 @@ export default {
     async updateStakes() {
       this.loading = true
       // the sort query sent to index needs to include "-created", but this is hidden from user in browser url
-      const sortQuery = this.$route.query.sort ? this.$route.query.sort + ',-created' : '-created'
+      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-created` : '-created'
       const stakes = await index.stake.stakes(
         process.env.VUE_APP_INDEX_API_URL,
         this.address,

--- a/src/components/TableHeader.vue
+++ b/src/components/TableHeader.vue
@@ -67,7 +67,7 @@ export default {
 
 <style scoped>
 th {
-  @apply font-normal text-sm2 text-left text-black bg-gray-100 border-b-2 border-gray-200 py-13 px-5;
+  @apply font-normal text-sm2 text-left text-black bg-gray-100 border-b-2 border-gray-200 py-13 px-5 cursor-pointer;
 }
 
 th.amount-col {

--- a/src/components/TableHeader.vue
+++ b/src/components/TableHeader.vue
@@ -46,16 +46,13 @@ export default {
       // - if param already in sorting list, bring to front (as descending)
       // - if param not in list, add to front of list (as descending)
 
-      if (!this.sortQuery) {
-        this.onSortingUpdate('-' + sortParam.replace(',', ',-'))
-      }
-
       // some sortParams will have multiple words (e.g. 'released,unlockRequested') so need hyphen at start of each word
       const sortRegexStr = '-?' + sortParam.replace(',', ',-?') + ',?'
       const startRegex = new RegExp('^' + sortRegexStr)
       const midRegex = new RegExp(sortRegexStr)
 
-      if (startRegex.test(this.sortQuery)) {
+      if (!this.sortQuery) this.onSortingUpdate('-' + sortParam.replace(',', ',-'))
+      else if (startRegex.test(this.sortQuery)) {
         let replaceString = sortParam
         if (!new RegExp('^' + sortRegexStr + '$').test(this.sortQuery)) replaceString += ','
         if (this.sortQuery[0] === '-') this.onSortingUpdate(this.sortQuery.replace(startRegex, replaceString))
@@ -64,7 +61,7 @@ export default {
       else {
         let sortParamDesc = '-' + sortParam.replace(',', ',-')
         // if there are more sort params, add comma after new sort param, plus remove any trailing commas and whitespace
-        if (this.sortQuery) sortParamDesc += ',' + this.sortQuery.replace(midRegex, '').replace(/,\s*$/, '')
+        if (this.sortQuery) sortParamDesc += ',' + this.sortQuery.replace(midRegex, '').replace(/,$/, '')
         this.onSortingUpdate(sortParamDesc)
       }
     }

--- a/src/components/TableHeader.vue
+++ b/src/components/TableHeader.vue
@@ -37,7 +37,7 @@ export default {
       return regex.test(this.sortQuery)
     },
     isDescending(expression) {
-      const regex = new RegExp('-' + expression.replace(',', ',-'))
+      const regex = new RegExp(`-${expression.replace(',', ',-')}`)
       return regex.test(this.sortQuery)
     },
     updateSorting(sortParam) {
@@ -48,18 +48,22 @@ export default {
 
       // some sortParams will have multiple words (e.g. 'released,unlockRequested') so need hyphen at start of each word
       const sortRegexStr = '-?' + sortParam.replace(',', ',-?') + ',?'
+      // startRegex - expression at start of sort query only
+      // midRegex - expression in middle or at end of sort query
+      // fullRegex - expression matches full query (i.e. only one sort param present)
       const startRegex = new RegExp('^' + sortRegexStr)
       const midRegex = new RegExp(sortRegexStr)
+      const fullRegex = new RegExp(`^${sortRegexStr}$`)
 
-      if (!this.sortQuery) this.onSortingUpdate('-' + sortParam.replace(',', ',-'))
+      if (!this.sortQuery) this.onSortingUpdate(`-${sortParam.replace(',', ',-')}`)
       else if (startRegex.test(this.sortQuery)) {
         let replaceString = sortParam
-        if (!new RegExp('^' + sortRegexStr + '$').test(this.sortQuery)) replaceString += ','
+        if (!fullRegex.test(this.sortQuery)) replaceString += ','
         if (this.sortQuery[0] === '-') this.onSortingUpdate(this.sortQuery.replace(startRegex, replaceString))
         else this.onSortingUpdate(this.sortQuery.replace(startRegex, ''))
       }
       else {
-        let sortParamDesc = '-' + sortParam.replace(',', ',-')
+        let sortParamDesc = `-${sortParam.replace(',', ',-')}`
         // if there are more sort params, add comma after new sort param, plus remove any trailing commas and whitespace
         if (this.sortQuery) sortParamDesc += ',' + this.sortQuery.replace(midRegex, '').replace(/,$/, '')
         this.onSortingUpdate(sortParamDesc)

--- a/src/components/TableHeader.vue
+++ b/src/components/TableHeader.vue
@@ -46,19 +46,26 @@ export default {
       // - if param already in sorting list, bring to front (as descending)
       // - if param not in list, add to front of list (as descending)
 
+      if (!this.sortQuery) {
+        this.onSortingUpdate('-' + sortParam.replace(',', ',-'))
+      }
+
       // some sortParams will have multiple words (e.g. 'released,unlockRequested') so need hyphen at start of each word
-      const sortRegexStr = '-?' + sortParam.replace(',', ',-?') + ','
+      const sortRegexStr = '-?' + sortParam.replace(',', ',-?') + ',?'
       const startRegex = new RegExp('^' + sortRegexStr)
       const midRegex = new RegExp(sortRegexStr)
 
       if (startRegex.test(this.sortQuery)) {
-        if (this.sortQuery[0] === '-') this.onSortingUpdate(this.sortQuery.replace(startRegex, sortParam + ','))
+        let replaceString = sortParam
+        if (!new RegExp('^' + sortRegexStr + '$').test(this.sortQuery)) replaceString += ','
+        if (this.sortQuery[0] === '-') this.onSortingUpdate(this.sortQuery.replace(startRegex, replaceString))
         else this.onSortingUpdate(this.sortQuery.replace(startRegex, ''))
       }
       else {
-        const sortParamDesc = '-' + sortParam.replace(',', ',-')
-        const newQuery = sortParamDesc + ',' + this.sortQuery.replace(midRegex, '')
-        this.onSortingUpdate(newQuery)
+        let sortParamDesc = '-' + sortParam.replace(',', ',-')
+        // if there are more sort params, add comma after new sort param, plus remove any trailing commas and whitespace
+        if (this.sortQuery) sortParamDesc += ',' + this.sortQuery.replace(midRegex, '').replace(/,\s*$/, '')
+        this.onSortingUpdate(sortParamDesc)
       }
     }
   }


### PR DESCRIPTION
- hide the `-created` sorting param from browser query, but keep it for the index query
- add `cursor: pointer` to the headers
- minor tweak to the order of the sorting logic

I haven't been able to fix the re-rendering issue (#200) , despite numerous attempts. I have asked anny to pick that one up when he's back