### PR TITLE
Feature/refactor tx table and sorting

### DIFF
--- a/src/components/Overviews.vue
+++ b/src/components/Overviews.vue
@@ -8,7 +8,7 @@
     </div>
 
     <div class="transactions-items" v-if="transactions">
-      <TransactionsTable :transactions="transactions"/>
+      <TransactionsTable :transactions="transactions" :limit="10" />
     </div>
   </div>
 </template>

--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -37,7 +37,6 @@
         v-for="item in stakes"
         :key="item.id"
         :item="item"
-        :sortable="sortable"
         :openReleaseStakeModal="openReleaseStakeModal"
         :openUnlockStakeModal="openUnlockStakeModal"
       />

--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -18,7 +18,7 @@
           sortParam="type" :onSortingUpdate="updateSorting"
         />
         <TableHeader width="8%" header="Status" :sortQuery="sortQuery"
-          sortParam="released,unlockRequested" :onSortingUpdate="updateSorting"
+          sortParam="sortStatus" :onSortingUpdate="updateSorting"
         />
         <TableHeader class="amount-col" width="10%" header="Amount XE" :sortQuery="sortQuery"
           sortParam="amount" :onSortingUpdate="updateSorting"
@@ -39,7 +39,7 @@
           sortParam="type" :onSortingUpdate="updateSorting"
         />
         <TableHeader width="8%" header="Status" :sortQuery="sortQuery"
-          sortParam="released,unlockRequested" :onSortingUpdate="updateSorting"
+          sortParam="sortStatus" :onSortingUpdate="updateSorting"
         />
         <TableHeader class="amount-col" width="10%" header="Amount XE" :sortQuery="sortQuery"
           sortParam="amount" :onSortingUpdate="updateSorting"

--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -1,31 +1,7 @@
 <template>
   <table>
     <thead class="hidden lg:table-header-group">
-      <tr v-if="!hideWalletColumn">
-        <TableHeader width="10%" header="ID" :sortQuery="sortQuery"
-          sortParam="id" :onSortingUpdate="updateSorting"
-        />
-        <TableHeader width="10%" header="Hash" :sortQuery="sortQuery"
-          sortParam="hash" :onSortingUpdate="updateSorting"
-        />
-        <TableHeader width="20%" header="Wallet" :sortQuery="sortQuery"
-          sortParam="wallet" :onSortingUpdate="updateSorting"
-        />
-        <TableHeader width="24%" header="Device" :sortQuery="sortQuery"
-          sortParam="device" :onSortingUpdate="updateSorting"
-        />
-        <TableHeader width="8%" header="Type" :sortQuery="sortQuery"
-          sortParam="type" :onSortingUpdate="updateSorting"
-        />
-        <TableHeader width="8%" header="Status" :sortQuery="sortQuery"
-          sortParam="sortStatus" :onSortingUpdate="updateSorting"
-        />
-        <TableHeader class="amount-col" width="10%" header="Amount XE" :sortQuery="sortQuery"
-          sortParam="amount" :onSortingUpdate="updateSorting"
-        />
-        <th width="10%" v-if="stakes.length">&nbsp;</th>
-      </tr>
-      <tr v-else>
+      <tr v-if="sortable">
         <TableHeader width="19%" header="ID" :sortQuery="sortQuery"
           sortParam="id" :onSortingUpdate="updateSorting"
         />
@@ -46,13 +22,22 @@
         />
         <th width="10%" v-if="stakes.length">&nbsp;</th>
       </tr>
+      <tr v-else>
+        <th width="19%">ID</th>
+        <th width="19%">Hash</th>
+        <th width="26%">Device</th>
+        <th width="8%">Type</th>
+        <th width="8%">Status</th>
+        <th class="amount-col" width="10%">Amount XE</th>
+        <th width="10%" v-if="stakes.length">&nbsp;</th>
+      </tr>
     </thead>
     <tbody v-if="stakes.length">
       <StakesTableItem
         v-for="item in stakes"
         :key="item.id"
         :item="item"
-        :hideWalletColumn="hideWalletColumn"
+        :sortable="sortable"
         :openReleaseStakeModal="openReleaseStakeModal"
         :openUnlockStakeModal="openUnlockStakeModal"
       />
@@ -92,10 +77,10 @@ export default {
     TableHeader
   },
   props: [
-    'hideWalletColumn',
     'limit',
     'page',
     'receiveMetadata',
+    'sortable',
     'openReleaseStakeModal',
     'openUnlockStakeModal'
   ],

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -14,14 +14,6 @@
       </span>
     </td>
 
-    <td v-if="!hideWalletColumn" data-title="Wallet:">
-      <a :href="explorerWalletUrl" target="_blank" rel="noreferrer">
-        <span class="monospace md:inline-block">
-          {{ item.tx.recipient }}
-        </span>
-      </a>
-    </td>
-
     <td data-title="Device:">
       <span v-if="item.device">
         <span class="monospace md:inline-block">
@@ -80,7 +72,7 @@ import { ArrowCircleDownIcon, CheckCircleIcon, ClockIcon, DotsCircleHorizontalIc
 
 export default {
   name: 'StakesTableItem',
-  props: ['hideWalletColumn', 'item', 'openReleaseStakeModal', 'openUnlockStakeModal'],
+  props: ['item', 'openReleaseStakeModal', 'openUnlockStakeModal'],
   components: {
     ArrowCircleDownIcon,
     CheckCircleIcon,

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -2,7 +2,7 @@
   <div class="transaction-table">
     <table>
       <thead class="hidden lg:table-header-group">
-        <tr>
+        <tr v-if="sortable">
           <TableHeader width="10%" header="Tx Hash" :sortQuery="sortQuery"
             sortParam="hash" :onSortingUpdate="updateSorting"
           />
@@ -21,6 +21,14 @@
           <TableHeader  class="amount-col" width="15%" header="Amount XE" :sortQuery="sortQuery"
             sortParam="amount" :onSortingUpdate="updateSorting"
           />
+        </tr>
+        <tr v-else>
+          <th width="10%">Tx Hash</th>
+          <th width="30%">From/To</th>
+          <th width="20%">Memo</th>
+          <th width="15%">Date</th>
+          <th width="10%">Status</th>
+          <th class="amount-col" width="15%">Amount XE</th>
         </tr>
       </thead>
       <tbody v-if="transactions.length">
@@ -68,7 +76,8 @@ export default {
   props: [
     'limit',
     'page',
-    'receiveMetadata'
+    'receiveMetadata',
+    'sortable'
   ],
   computed: {
     ...mapState(['address']),
@@ -101,7 +110,7 @@ export default {
         }
       )
       this.transactions = transactions.results
-      this.receiveMetadata(transactions.metadata)
+      if (this.receiveMetadata) this.receiveMetadata(transactions.metadata)
       this.loading = false
     },
     updateSorting(newSortQuery) {

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -2,21 +2,24 @@
   <div class="transaction-table">
     <table>
       <thead class="hidden lg:table-header-group">
-      <tr>
-        <th width="10%">Tx Hash</th>
-        <th width="12%">Date</th>
-        <th width="33%">From/To</th>
-        <th width="16%">Memo</th>
-        <th width="12%">Status</th>
-        <th width="20%">Amount XE</th>
-      </tr>
+        <tr>
+          <th width="10%">Tx Hash</th>
+          <th width="15%">Date</th>
+          <th width="30%">From/To</th>
+          <th width="20%">Memo</th>
+          <th width="10%">Status</th>
+          <th width="15%" class="amount-col">Amount XE</th>
+        </tr>
       </thead>
       <tbody v-if="transactions.length">
-        <tr v-for="item in transactions" :key="item.id" :class="item.pending ? 'italic text-gray-400' : ''">
-          <TransactionsTableItem :item="item"/>
-        </tr>
+        <TransactionsTableItem
+          v-for="item in transactions"
+          :key="item.hash"
+          :item="item"
+          :hideWalletColumn="hideWalletColumn"
+        />
       </tbody>
-      <tbody v-if="!transactions.length">
+      <tbody v-else>
         <tr>
           <td colspan="7" class="block w-full text-center bg-white lg:table-cell py-35">
             No transactions.
@@ -28,37 +31,118 @@
 </template>
 
 <script>
+/*global process*/
+
+import * as index from '@edge/index-utils'
+// import TableHeader from '@/components/TableHeader'
 import TransactionsTableItem from '@/components/TransactionsTableItem'
+import { mapState } from 'vuex'
+
+const txsRefreshInterval = 5 * 1000
 
 export default {
   name: 'TransactionsTable',
-  components: {TransactionsTableItem},
-  props: ['transactions'],
+  data: function () {
+    return {
+      loading: false,
+      metadata: null,
+      transactions: [],
+      iTransactions: null
+    }
+  },
+  components: {
+    // TableHeader,
+    TransactionsTableItem
+  },
+  props: [
+    'hideWalletColumn',
+    'limit',
+    'page',
+    'receiveMetadata'
+  ],
+  computed: {
+    ...mapState(['address']),
+    sortQuery() {
+      return this.$route.query.sort
+    }
+  },
+  mounted() {
+    this.updateTransactions()
+    // initiate polling
+    this.iStakes = setInterval(() => {
+      this.updateTransactions()
+    }, txsRefreshInterval)
+  },
+  unmounted() {
+    clearInterval(this.iStakes)
+  },
   methods: {
+    async updateTransactions() {
+      this.loading = true
+      // the sort query sent to index needs to include "-created", but this is hidden from user in browser url
+      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-timestamp` : '-timestamp'
+      const transactions = await index.tx.transactions(
+        process.env.VUE_APP_INDEX_API_URL,
+        this.address,
+        {
+          limit: this.limit,
+          page: this.page,
+          sort: sortQuery
+        }
+      )
+      this.transactions = transactions.results
+      this.receiveMetadata(transactions.metadata)
+      this.loading = false
+    },
+    updateSorting(newSortQuery) {
+      const query = { ...this.$route.query, sort: newSortQuery }
+      if (!newSortQuery) delete query.sort
+      this.$router.replace({ query })
+    }
+  },
+  watch: {
+    page() {
+      this.updateTransactions()
+    },
+    sortQuery() {
+      this.updateTransactions()
+    }
   }
 }
 </script>
 
 <style scoped>
+table {
+  @apply w-full table-fixed
+}
+
 table, tbody, tr {
   @apply block;
 }
 
 th {
-  @apply font-normal text-sm2 text-left text-black bg-gray-100 border-b-2 border-gray-200;
+  @apply font-normal text-sm2 text-left text-black bg-gray-100 border-b-2 border-gray-200 py-13 px-5;
 }
 
-th:last-child {
-  @apply rounded-r-4 text-right;
+th:first-of-type {
+  @apply pl-20;
+}
+
+th.amount-col {
+  @apply text-right
+}
+
+th .icon {
+  @apply w-15 inline-block align-middle text-gray-400;
 }
 
 @screen lg {
-  tbody {
-    @apply table-row-group;
-  }
-
   table {
     @apply table;
+  }
+
+  tbody {
+    @apply table-row-group;
   }
 
   tr {

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -4,9 +4,9 @@
       <thead class="hidden lg:table-header-group">
         <tr>
           <th width="10%">Tx Hash</th>
-          <th width="15%">Date</th>
           <th width="30%">From/To</th>
           <th width="20%">Memo</th>
+          <th width="15%">Date</th>
           <th width="10%">Status</th>
           <th width="15%" class="amount-col">Amount XE</th>
         </tr>
@@ -16,7 +16,6 @@
           v-for="item in transactions"
           :key="item.hash"
           :item="item"
-          :hideWalletColumn="hideWalletColumn"
         />
       </tbody>
       <tbody v-else>
@@ -55,7 +54,6 @@ export default {
     TransactionsTableItem
   },
   props: [
-    'hideWalletColumn',
     'limit',
     'page',
     'receiveMetadata'

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -40,7 +40,7 @@
       </tbody>
       <tbody v-else>
         <tr>
-          <td colspan="7" class="block w-full text-center bg-white lg:table-cell py-35">
+          <td colspan="6" class="block w-full text-center bg-white lg:table-cell py-35">
             No transactions.
           </td>
         </tr>
@@ -88,12 +88,12 @@ export default {
   mounted() {
     this.updateTransactions()
     // initiate polling
-    this.iStakes = setInterval(() => {
+    this.iTransactions = setInterval(() => {
       this.updateTransactions()
     }, txsRefreshInterval)
   },
   unmounted() {
-    clearInterval(this.iStakes)
+    clearInterval(this.iTransactions)
   },
   methods: {
     async updateTransactions() {

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -7,7 +7,7 @@
             sortParam="hash" :onSortingUpdate="updateSorting"
           />
           <TableHeader width="30%" header="From/To" :sortQuery="sortQuery"
-            sortParam="toOrFrom" :onSortingUpdate="updateSorting"
+            sortParam="sortAddress" :onSortingUpdate="updateSorting"
           />
           <TableHeader width="20%" header="Memo" :sortQuery="sortQuery"
             sortParam="data.memo" :onSortingUpdate="updateSorting"

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -3,12 +3,24 @@
     <table>
       <thead class="hidden lg:table-header-group">
         <tr>
-          <th width="10%">Tx Hash</th>
-          <th width="30%">From/To</th>
-          <th width="20%">Memo</th>
-          <th width="15%">Date</th>
-          <th width="10%">Status</th>
-          <th width="15%" class="amount-col">Amount XE</th>
+          <TableHeader width="10%" header="Tx Hash" :sortQuery="sortQuery"
+            sortParam="hash" :onSortingUpdate="updateSorting"
+          />
+          <TableHeader width="30%" header="From/To" :sortQuery="sortQuery"
+            sortParam="toOrFrom" :onSortingUpdate="updateSorting"
+          />
+          <TableHeader width="20%" header="Memo" :sortQuery="sortQuery"
+            sortParam="data.memo" :onSortingUpdate="updateSorting"
+          />
+          <TableHeader width="15%" header="Date" :sortQuery="sortQuery"
+            sortParam="timestamp" :onSortingUpdate="updateSorting"
+          />
+          <TableHeader width="10%" header="Status" :sortQuery="sortQuery"
+            sortParam="block.height" :onSortingUpdate="updateSorting"
+          />
+          <TableHeader  class="amount-col" width="15%" header="Amount XE" :sortQuery="sortQuery"
+            sortParam="amount" :onSortingUpdate="updateSorting"
+          />
         </tr>
       </thead>
       <tbody v-if="transactions.length">
@@ -33,7 +45,7 @@
 /*global process*/
 
 import * as index from '@edge/index-utils'
-// import TableHeader from '@/components/TableHeader'
+import TableHeader from '@/components/TableHeader'
 import TransactionsTableItem from '@/components/TransactionsTableItem'
 import { mapState } from 'vuex'
 
@@ -50,7 +62,7 @@ export default {
     }
   },
   components: {
-    // TableHeader,
+    TableHeader,
     TransactionsTableItem
   },
   props: [

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -8,24 +8,18 @@
       </a>
     </td>
 
-    <td data-title="Date:">
-      <span class="md:inline-block">
-        {{ date }}
-      </span>
-    </td>
-
-    <td v-if="type === 'sent'" data-title="To:">
-      <div class="icon-wrap">
+    <td v-if="sent" data-title="To:">
+      <span class="icon-wrap">
         <span class="mr-1 -mt-2 icon icon-red"><ArrowUpIcon /></span>
         <a :href="explorerToAddressUrl" target="_blank" rel="noreferrer">
           <span class="monospace md:inline-block">
             {{ item.recipient }}
           </span>
         </a>
-      </div>
+      </span>
     </td>
     <td v-else data-title="From:">
-      <span>
+      <span class="icon-wrap">
         <span class="mr-1 -mt-2 icon icon-green"><ArrowDownIcon /></span>
         <a :href="explorerFromAddressUrl" target="_blank" rel="noreferrer">
           <span class="monospace md:inline-block">
@@ -37,6 +31,12 @@
 
     <td data-title="Memo:">
       <span class="monospace md:font-sans">{{ item.data.memo }}</span>
+    </td>
+
+    <td data-title="Date:">
+      <span class="md:inline-block">
+        {{ date }}
+      </span>
     </td>
 
     <td data-title="Status:">
@@ -54,7 +54,7 @@
 
     <td data-title="Amount (XE):" class="amount-col">
       <span class="monospace">
-        <span v-if="type === 'sent'">-</span>
+        <span v-if="sent">-</span>
         {{ formattedAmount }}
       </span>
     </td>
@@ -70,7 +70,11 @@ import { ArrowDownIcon, ArrowUpIcon, CheckCircleIcon, ClockIcon } from '@heroico
 
 export default {
   name: 'StakesTableItem',
-  props: ['hideWalletColumn', 'item', 'openReleaseStakeModal', 'openUnlockStakeModal'],
+  props: [
+    'item',
+    'openReleaseStakeModal',
+    'openUnlockStakeModal'
+  ],
   components: {
     ArrowDownIcon,
     ArrowUpIcon,
@@ -102,10 +106,8 @@ export default {
       if (this.item.confirmations < 10) return `${this.item.confirmations} confirmations`
       return 'Confirmed'
     },
-    type() {
-      if (this.item.sender === this.item.recipient) return 'received'
-      else if (this.address === this.sender) return 'sent'
-      else return 'received'
+    sent() {
+      return this.item.sender === this.item.recipient || this.address === this.item.sender
     }
   }
 }

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -66,6 +66,7 @@
 /*global process*/
 
 import { formatXe } from '@edge/wallet-utils'
+import { mapState } from 'vuex'
 import { ArrowDownIcon, ArrowUpIcon, CheckCircleIcon, ClockIcon } from '@heroicons/vue/outline'
 
 export default {
@@ -82,6 +83,7 @@ export default {
     ClockIcon
   },
   computed: {
+    ...mapState(['address']),
     date() {
       return new Date(this.item.timestamp).toLocaleString()
     },
@@ -98,10 +100,10 @@ export default {
       return formatXe(this.item.amount / 1e6, true)
     },
     isConfirmed() {
-      return (!this.pending || !this.confirmations < 10)
+      return (!this.item.block || !this.item.confirmations < 10)
     },
     statusFormatted() {
-      if (this.item.pending) return 'Pending'
+      if (!this.item.block) return 'Pending'
       if (this.item.confirmations === 1) return `${this.item.confirmations} confirmation`
       if (this.item.confirmations < 10) return `${this.item.confirmations} confirmations`
       return 'Confirmed'

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -72,9 +72,7 @@ import { ArrowDownIcon, ArrowUpIcon, CheckCircleIcon, ClockIcon } from '@heroico
 export default {
   name: 'StakesTableItem',
   props: [
-    'item',
-    'openReleaseStakeModal',
-    'openUnlockStakeModal'
+    'item'
   ],
   components: {
     ArrowDownIcon,

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -1,96 +1,112 @@
 <template>
-  <!-- eslint-disable vue/no-multiple-template-root -->
-  <td data-title="Tx Hash:" :title="item.hash">
-    <a :href="`${explorerUrl}/transaction/${item.hash}`" target="_blank" rel="noreferrer">
-      <span class="hidden monospace md:inline-block">{{ sliceString(item.hash, 8) }}</span>
-      <span class="monospace md:hidden">{{ sliceString(item.hash, 26) }}</span>
-    </a>
-  </td>
-  <td data-title="Date:">
-    <span class="monospace md:font-sans">
-      {{ item.date }}
-    </span>
-  </td>
-  <td data-title="Address:">
-    <span v-if="item.type.toLowerCase() === 'received'">
-      <span class="icon icon-green mr-4"><ArrowDownIcon /></span>
-      <a :href="`${explorerUrl}/wallet/${item.sender}`" target="_blank" rel="noreferrer">
-        <span class="hidden monospace md:inline-block">{{ item.sender }}</span>
+  <tr>
+    <td data-title="Tx Hash:" :title="item.hash">
+      <a :href="explorerTxUrl" target="_blank" rel="noreferrer">
+        <span class="monospace md:inline-block">
+          {{ item.hash }}
+        </span>
       </a>
-      <span class="monospace md:hidden">{{ sliceString(item.sender, 26) }}</span>
-    </span>
-    <span v-if="item.type.toLowerCase() === 'sent'">
-      <span class="icon icon-red mr-4"><ArrowUpIcon /></span>
-      <a :href="`${explorerUrl}/wallet/${item.recipient}`" target="_blank" rel="noreferrer">
-        <span class="hidden monospace md:inline-block">{{ item.recipient }}</span>
-      </a>
-      <span class="monospace md:hidden">{{ sliceString(item.recipient, 26) }}</span>
-    </span>
-  </td>
-  <td :title="item.description" data-title="Memo:" :class="item.description === 'None' ? 'text-gray-400' : ''">
-    <span class="monospace md:font-sans">{{ sliceString(item.description, 26) }}</span>
-  </td>
-  <td data-title="Status:">
-    <span v-if="!isConfirmed(item)" class="mr-1 -mt-2 icon icon--confirmed icon-grey">
-      <ClockIcon />
-    </span>
-    <span v-if="isConfirmed(item)" class="mr-1 -mt-2 icon icon--confirmed icon-green">
-      <CheckCircleIcon />
-    </span>
-    <span
-      class="monospace md:font-sans"
-      :class="item.confirmations < 10 || !item.confirmations ? 'text-gray-400' : ''"
-    >{{ formatStatus(item) }}</span>
-  </td>
-  <td data-title="Amount:">
-    <span class="monospace">
-      <span v-if="item.type.toLowerCase() === 'sent'">-</span><Amount :value="parseFloat(item.amount)"/>
-    </span>
-  </td>
+    </td>
+
+    <td data-title="Date:">
+      <span class="md:inline-block">
+        {{ date }}
+      </span>
+    </td>
+
+    <td v-if="type === 'sent'" data-title="To:">
+      <div class="icon-wrap">
+        <span class="mr-1 -mt-2 icon icon-red"><ArrowUpIcon /></span>
+        <a :href="explorerToAddressUrl" target="_blank" rel="noreferrer">
+          <span class="monospace md:inline-block">
+            {{ item.recipient }}
+          </span>
+        </a>
+      </div>
+    </td>
+    <td v-else data-title="From:">
+      <span>
+        <span class="mr-1 -mt-2 icon icon-green"><ArrowDownIcon /></span>
+        <a :href="explorerFromAddressUrl" target="_blank" rel="noreferrer">
+          <span class="monospace md:inline-block">
+            {{ item.sender }}
+          </span>
+        </a>
+      </span>
+    </td>
+
+    <td data-title="Memo:">
+      <span class="monospace md:font-sans">{{ item.data.memo }}</span>
+    </td>
+
+    <td data-title="Status:">
+      <span v-if="isConfirmed && item.confirmations > 10">
+        <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon /></span>
+        <span
+          class="monospace md:font-sans">{{ statusFormatted }}</span>
+      </span>
+      <span v-else>
+        <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
+        <span
+          class="monospace md:font-sans text-gray-400">{{ statusFormatted }}</span>
+      </span>
+    </td>
+
+    <td data-title="Amount (XE):" class="amount-col">
+      <span class="monospace">
+        <span v-if="type === 'sent'">-</span>
+        {{ formattedAmount }}
+      </span>
+    </td>
+
+  </tr>
 </template>
 
 <script>
 /*global process*/
 
-import Amount from './Amount'
+import { formatXe } from '@edge/wallet-utils'
 import { ArrowDownIcon, ArrowUpIcon, CheckCircleIcon, ClockIcon } from '@heroicons/vue/outline'
 
 export default {
-  name: 'TransactionsTableItem',
-  props: ['item'],
-  data: function() {
-    return {
-      explorerUrl: process.env.VUE_APP_EXPLORER_URL || 'https://xe.network'
-    }
-  },
-  methods: {
-    async copyToClipboard (input) {
-      if (navigator.clipboard) {
-        await navigator.clipboard.writeText(input)
-      }
-    },
-    sliceString(string, symbols) {
-      return string.length > symbols ? `${string.slice(0, symbols)}…` : string
-    },
-    formatStatus(item) {
-      if (item.pending) return 'Pending'
-      if (item.confirmations === 1) return `${item.confirmations} confirmation`
-      if (item.confirmations < 10) return `${item.confirmations} confirmations`
-      return 'Confirmed'
-    },
-    isConfirmed(item) {
-      if (item.pending) return false
-      if (item.confirmations === 1) return false
-      if (item.confirmations < 10) return false
-      return true
-    }
-  },
+  name: 'StakesTableItem',
+  props: ['hideWalletColumn', 'item', 'openReleaseStakeModal', 'openUnlockStakeModal'],
   components: {
-    Amount,
     ArrowDownIcon,
     ArrowUpIcon,
     CheckCircleIcon,
     ClockIcon
+  },
+  computed: {
+    date() {
+      return new Date(this.item.timestamp).toLocaleString()
+    },
+    explorerFromAddressUrl() {
+      return `${process.env.VUE_APP_EXPLORER_URL}/wallet/${this.item.sender}`
+    },
+    explorerToAddressUrl() {
+      return `${process.env.VUE_APP_EXPLORER_URL}/wallet/${this.item.recipient}`
+    },
+    explorerTxUrl() {
+      return `${process.env.VUE_APP_EXPLORER_URL}/transaction/${this.item.hash}`
+    },
+    formattedAmount() {
+      return formatXe(this.item.amount / 1e6, true)
+    },
+    isConfirmed() {
+      return (!this.pending || !this.confirmations < 10)
+    },
+    statusFormatted() {
+      if (this.item.pending) return 'Pending'
+      if (this.item.confirmations === 1) return `${this.item.confirmations} confirmation`
+      if (this.item.confirmations < 10) return `${this.item.confirmations} confirmations`
+      return 'Confirmed'
+    },
+    type() {
+      if (this.item.sender === this.item.recipient) return 'received'
+      else if (this.address === this.sender) return 'sent'
+      else return 'received'
+    }
   }
 }
 </script>
@@ -98,6 +114,18 @@ export default {
 <style scoped>
 td {
   @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4;
+}
+
+td span {
+  @apply w-full overflow-ellipsis overflow-hidden whitespace-nowrap
+}
+
+td a {
+  @apply overflow-ellipsis overflow-hidden whitespace-nowrap
+}
+
+.icon-wrap {
+  @apply flex overflow-ellipsis overflow-hidden whitespace-nowrap
 }
 
 td::before {
@@ -116,9 +144,6 @@ td:last-child {
 td .icon {
   @apply w-15 inline-block align-middle;
 }
-td .icon--confirmed {
-  @apply w-16 md:w-18;
-}
 
 td .icon-green {
   @apply text-green;
@@ -132,12 +157,12 @@ td .icon-red {
   @apply text-red;
 }
 
-td .arrow-icon {
-  @apply absolute hidden pt-px lg:block w-14 h-14 -left-14 text-green;
-}
-
 td a {
   @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+}
+
+button.table-button {
+  @apply py-2 rounded text-black border-solid border border-gray-400 text-gray-500 hover:border-green hover:text-green
 }
 
 @screen lg {
@@ -147,6 +172,10 @@ td a {
 
   td:first-child {
     @apply pl-20 pt-13;
+  }
+
+  td.amount-col {
+    @apply text-right
   }
 
   td:last-child {

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <tr>
+  <tr :class="isPending && 'pending'">
     <td data-title="Tx Hash:" :title="item.hash">
       <a :href="explorerTxUrl" target="_blank" rel="noreferrer">
         <span class="monospace md:inline-block">
@@ -100,10 +100,13 @@ export default {
       return formatXe(this.item.amount / 1e6, true)
     },
     isConfirmed() {
-      return (!this.item.block || !this.item.confirmations < 10)
+      return (!this.isPending || !this.item.confirmations < 10)
+    },
+    isPending() {
+      return !this.item.block
     },
     statusFormatted() {
-      if (!this.item.block) return 'Pending'
+      if (this.isPending) return 'Pending'
       if (this.item.confirmations === 1) return `${this.item.confirmations} confirmation`
       if (this.item.confirmations < 10) return `${this.item.confirmations} confirmations`
       return 'Confirmed'
@@ -165,8 +168,12 @@ td a {
   @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
-button.table-button {
-  @apply py-2 rounded text-black border-solid border border-gray-400 text-gray-500 hover:border-green hover:text-green
+tr.pending {
+  @apply italic text-gray-400
+}
+
+tr.pending a {
+  @apply italic text-gray-400
 }
 
 @screen lg {

--- a/src/views/Staking.vue
+++ b/src/views/Staking.vue
@@ -17,10 +17,10 @@
     <div class="bg-gray-200 py-35">
       <div class="container">
         <StakesTable
-          :hideWalletColumn="true"
           :limit="limit"
           :receiveMetadata="onStakesUpdate"
           :page="currentPage"
+          :sortable="true"
           :openReleaseStakeModal="openReleaseStakeModal"
           :openUnlockStakeModal="openUnlockStakeModal"
         />

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -6,7 +6,6 @@
     <div class="bg-gray-200 py-35">
       <div class="container">
         <TransactionsTable
-          :hideWalletColumn="true"
           :limit="limit"
           :receiveMetadata="onTransactionsUpdate"
           :page="currentPage"

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -9,6 +9,7 @@
           :limit="limit"
           :receiveMetadata="onTransactionsUpdate"
           :page="currentPage"
+          :sortable="true"
         />
         <Pagination
           v-if="metadata.totalCount > limit"


### PR DESCRIPTION
- Complete refactor of the Transaction view/table to be more similar to the Staking.
- Added sorting to the table so columns can all be sorted desc/asc (if no sorting applied, it defaults to sort by created date, desc.)
- Utilises the new pending txs from index (rather than fetching directly from blockchain as done previously). This needs [this PR ](https://github.com/edge/index/pull/111) to be merged before it will work, and Explorer needs updating too to no longer get pending txs direct from blockchain (I'll work on that now)
- Txs that are sent to yourself (e.g. any tx related to stakes) will be displayed only once, and as a "sent" transaction.  