### PR TITLE
Fix/misc fixes 4 3 22

### DIFF
--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -41,6 +41,11 @@
         :openUnlockStakeModal="openUnlockStakeModal"
       />
     </tbody>
+    <tbody v-else-if="!loaded && loading">
+      <td :colspan="!wallet ? 8 : 6" class="block w-full text-center bg-white lg:table-cell py-35">
+        Loading...
+      </td>
+    </tbody>
     <tbody v-else>
       <tr>
         <td colspan="7" class="block w-full text-center bg-white lg:table-cell py-35">
@@ -65,6 +70,7 @@ export default {
   name: 'StakesTable',
   data: function () {
     return {
+      loaded: false,
       loading: false,
       metadata: null,
       stakes: [],
@@ -115,6 +121,7 @@ export default {
       )
       this.stakes = stakes.results
       this.receiveMetadata(stakes.metadata)
+      this.loaded = true
       this.loading = false
     },
     updateSorting(newSortQuery) {

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -38,6 +38,11 @@
           :item="item"
         />
       </tbody>
+      <tbody v-else-if="!loaded && loading">
+        <td :colspan="!wallet ? 8 : 6" class="block w-full text-center bg-white lg:table-cell py-35">
+          Loading...
+        </td>
+      </tbody>
       <tbody v-else>
         <tr>
           <td colspan="6" class="block w-full text-center bg-white lg:table-cell py-35">
@@ -63,6 +68,7 @@ export default {
   name: 'TransactionsTable',
   data: function () {
     return {
+      loaded: false,
       loading: false,
       metadata: null,
       transactions: [],
@@ -111,6 +117,7 @@ export default {
       )
       this.transactions = transactions.results
       if (this.receiveMetadata) this.receiveMetadata(transactions.metadata)
+      this.loaded = true
       this.loading = false
     },
     updateSorting(newSortQuery) {

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -3,6 +3,9 @@
     <table>
       <thead class="hidden lg:table-header-group">
         <tr v-if="sortable">
+          <TableHeader width="15%" header="Date" :sortQuery="sortQuery"
+            sortParam="timestamp" :onSortingUpdate="updateSorting"
+          />
           <TableHeader width="10%" header="Tx Hash" :sortQuery="sortQuery"
             sortParam="hash" :onSortingUpdate="updateSorting"
           />
@@ -11,9 +14,6 @@
           />
           <TableHeader width="20%" header="Memo" :sortQuery="sortQuery"
             sortParam="data.memo" :onSortingUpdate="updateSorting"
-          />
-          <TableHeader width="15%" header="Date" :sortQuery="sortQuery"
-            sortParam="timestamp" :onSortingUpdate="updateSorting"
           />
           <TableHeader width="10%" header="Status" :sortQuery="sortQuery"
             sortParam="block.height" :onSortingUpdate="updateSorting"

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -1,5 +1,11 @@
 <template>
   <tr :class="isPending && 'pending'">
+    <td data-title="Date:">
+      <span class="md:inline-block">
+        {{ date }}
+      </span>
+    </td>
+
     <td data-title="Tx Hash:" :title="item.hash">
       <a :href="explorerTxUrl" target="_blank" rel="noreferrer">
         <span class="monospace md:inline-block">
@@ -30,16 +36,12 @@
     </td>
 
     <td data-title="Memo:">
-      <span class="monospace md:font-sans">{{ item.data.memo }}</span>
-    </td>
-
-    <td data-title="Date:">
-      <span class="md:inline-block">
-        {{ date }}
+      <span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray'">
+        {{ item.data.memo || 'None' }}
       </span>
     </td>
 
-    <td data-title="Status:">
+  <td data-title="Status:">
       <span v-if="isConfirmed && item.confirmations > 10">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon /></span>
         <span
@@ -54,8 +56,7 @@
 
     <td data-title="Amount (XE):" class="amount-col">
       <span class="monospace">
-        <span v-if="sent">-</span>
-        {{ formattedAmount }}
+        {{ `${sent ? '-' : ''}${formattedAmount}` }}
       </span>
     </td>
 


### PR DESCRIPTION
- moved date to first column of tx table (to match explorer)
- removed space between negative sign and amount for outgoing txs (ie. - 15.0000  ->   -15.00000)
- added "none" in gray text when there is no memo on a tx
- added a "loading" message when data is loading, similar to what I did in explorer. This doesn't show each time data is fetched