### PR TITLE
Fix/misc fixes 17 03

### DIFF
--- a/src/components/RecentBlocks.vue
+++ b/src/components/RecentBlocks.vue
@@ -155,7 +155,7 @@ td .icon-grey {
   }
 
   td {
-    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-13 table-cell border-b-2 align-middle;
   }
 
   td:first-child {
@@ -163,7 +163,7 @@ td .icon-grey {
   }
 
   td:last-child {
-    @apply pr-30 pb-10 border-b-2;
+    @apply pr-30 pb-13 border-b-2;
   }
 
   td:before {

--- a/src/components/RecentBlocks.vue
+++ b/src/components/RecentBlocks.vue
@@ -6,8 +6,10 @@
       <thead class="hidden lg:table-header-group">
         <tr>
           <th width="15%">Height</th>
-          <th width="52%">Hash</th>
-          <th>Mined</th>
+          <th width="20%">Hash</th>
+          <th width="10%">Txs</th>
+          <th width="25%" class="amount-col">Total XE</th>
+          <th width="30%">Mined</th>
         </tr>
       </thead>
       <tbody v-if="loading">
@@ -20,18 +22,29 @@
       <tbody v-if="blocks.length">
         <tr v-for="block in blocks" :key="block.hash">
           <td data-title="Height:">
-            <a :href="`${explorerUrl}/block/${block.height}`" target="_blank" rel="noreferrer" class="monospace">
+            <!-- eslint-disable-next-line max-len -->
+            <a :href="`${explorerUrl}/block/${block.height}`" target="_blank" rel="noreferrer" class="monospace lg:inline-block">
               {{ block.height }}
             </a>
           </td>
           <td data-title="Hash:" :title="block.hash">
             <a :href="`${explorerUrl}/block/${block.hash}`" target="_blank" rel="noreferrer">
-              <span class="monospace">{{ block.hash.substr(0, 32) }}</span>
+              <span class="monospace lg:inline-block">{{ block.hash }}</span>
             </a>
           </td>
+          <td data-title="Txs:">
+            <span class="monospace lg:inline-block">{{ block.transactions.length }}</span>
+          </td>
+          <td data-title="Total XE:" class="amount-col">
+            <span class="monospace lg:inline-block">{{ formatAmount(block.total) }}</span>
+          </td>
           <td data-title="Mined:" class="text-gray-600 lg:text-gray">
-            <span class="mr-1 lg:-mt-2 icon icon-grey"><ClockIcon /></span>
-            {{ timeSince(block.timestamp) }}
+            <span class="lg:inline-block">
+              <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon /></span>
+              <span class="monospace lg:font-sans lg:text-gray-400">
+                {{ timeSince(block.timestamp) }}
+              </span>
+            </span>
           </td>
         </tr>
       </tbody>
@@ -43,6 +56,7 @@
 /*global process*/
 import { ClockIcon } from '@heroicons/vue/outline'
 import { fetchBlocks } from '../utils/api'
+import { formatXe } from '@edge/wallet-utils'
 import moment from 'moment'
 
 export default {
@@ -71,6 +85,9 @@ export default {
       this.blocks = blocks
       this.loading = false
     },
+    formatAmount(amount) {
+      return formatXe(amount / 1e6, true)
+    },
     pollData() {
       this.polling = setInterval(() => {
         this.fetchBlocks()
@@ -88,8 +105,16 @@ table, tbody, tr {
   @apply block;
 }
 
+table {
+  @apply w-full table-fixed
+}
+
 th {
   @apply font-normal text-sm2 text-left text-black bg-gray-100 px-5 border-b-2 border-gray-200 py-8 leading-tight;
+}
+
+th.amount-col {
+  @apply text-right pr-30
 }
 
 th:last-child {
@@ -105,11 +130,11 @@ td a {
 }
 
 td span {
-  @apply w-full overflow-ellipsis overflow-hidden whitespace-nowrap
+  @apply w-full overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
 td a {
-  @apply overflow-ellipsis overflow-hidden whitespace-nowrap
+  @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
 td::before {
@@ -156,6 +181,10 @@ td .icon-grey {
 
   td {
     @apply border-gray-200 pt-13 pb-13 table-cell border-b-2 align-middle;
+  }
+
+  td.amount-col {
+    @apply text-right pr-30;
   }
 
   td:first-child {

--- a/src/components/RecentBlocks.vue
+++ b/src/components/RecentBlocks.vue
@@ -30,7 +30,7 @@
             </a>
           </td>
           <td data-title="Mined:" class="text-gray-600 lg:text-gray">
-            <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon /></span>
+            <span class="mr-1 lg:-mt-2 icon icon-grey"><ClockIcon /></span>
             {{ timeSince(block.timestamp) }}
           </td>
         </tr>
@@ -89,7 +89,7 @@ table, tbody, tr {
 }
 
 th {
-  @apply font-normal text-sm2 text-left text-black bg-gray-100 px-5 border-b-2 border-gray-200 py-8;
+  @apply font-normal text-sm2 text-left text-black bg-gray-100 px-5 border-b-2 border-gray-200 py-8 leading-tight;
 }
 
 th:last-child {
@@ -101,7 +101,7 @@ td {
 }
 
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
 td span {
@@ -155,7 +155,7 @@ td .icon-grey {
   }
 
   td {
-    @apply border-gray-200 pt-13 pb-14 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
   }
 
   td:first-child {
@@ -163,7 +163,7 @@ td .icon-grey {
   }
 
   td:last-child {
-    @apply pr-30 pb-13 border-b-2;
+    @apply pr-30 pb-10 border-b-2;
   }
 
   td:before {

--- a/src/components/RecentBlocks.vue
+++ b/src/components/RecentBlocks.vue
@@ -19,8 +19,8 @@
       </tbody>
       <tbody v-if="blocks.length">
         <tr v-for="block in blocks" :key="block.hash">
-          <td data-title="Height:" class="monospace">
-            <a :href="`${explorerUrl}/block/${block.height}`" target="_blank" rel="noreferrer">
+          <td data-title="Height:">
+            <a :href="`${explorerUrl}/block/${block.height}`" target="_blank" rel="noreferrer" class="monospace">
               {{ block.height }}
             </a>
           </td>
@@ -29,7 +29,8 @@
               <span class="monospace">{{ block.hash.substr(0, 32) }}</span>
             </a>
           </td>
-          <td data-title="Mined:">
+          <td data-title="Mined:" class="text-gray-600 lg:text-gray">
+            <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon /></span>
             {{ timeSince(block.timestamp) }}
           </td>
         </tr>
@@ -40,6 +41,7 @@
 
 <script>
 /*global process*/
+import { ClockIcon } from '@heroicons/vue/outline'
 import { fetchBlocks } from '../utils/api'
 import moment from 'moment'
 
@@ -53,6 +55,9 @@ export default {
       blocks: [],
       isTestnet: process.env.VUE_APP_IS_TESTNET === 'true'
     }
+  },
+  components: {
+    ClockIcon
   },
   mounted() {
     this.loading = true
@@ -87,10 +92,6 @@ th {
   @apply font-normal text-sm2 text-left text-black bg-gray-100 px-5 border-b-2 border-gray-200 py-8;
 }
 
-/* th:first-child {
-  @apply pt-8;
-} */
-
 th:last-child {
   @apply rounded-r-4;
 }
@@ -103,9 +104,17 @@ td a {
   @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
+td span {
+  @apply w-full overflow-ellipsis overflow-hidden whitespace-nowrap
+}
+
+td a {
+  @apply overflow-ellipsis overflow-hidden whitespace-nowrap
+}
+
 td::before {
   content: attr(data-title);
-  @apply font-bold mr-8 min-w-100;
+  @apply font-normal mr-8 min-w-100 text-xs text-gray-600 pt-2;
 }
 
 td:first-child {
@@ -114,6 +123,14 @@ td:first-child {
 
 td:last-child {
   @apply rounded-r-4 pb-8 border-b-4 border-gray-200;
+}
+
+td .icon {
+  @apply w-15 inline-block align-middle;
+}
+
+td .icon-grey {
+  @apply lg:text-gray-400;
 }
 
 @screen lg {

--- a/src/components/RecentBlocks.vue
+++ b/src/components/RecentBlocks.vue
@@ -24,7 +24,7 @@
               {{ block.height }}
             </a>
           </td>
-          <td data-title="Hash:">
+          <td data-title="Hash:" :title="block.hash">
             <a :href="`${explorerUrl}/block/${block.hash}`" target="_blank" rel="noreferrer">
               <span class="monospace">{{ block.hash.substr(0, 32) }}</span>
             </a>

--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -25,7 +25,7 @@
       <tr v-else>
         <th width="19%">ID</th>
         <th width="19%">Hash</th>
-        <th width="26%">Device</th>
+        <th width="26%">Node</th>
         <th width="8%">Type</th>
         <th width="8%">Status</th>
         <th class="amount-col" width="10%">Amount XE</th>

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -8,13 +8,13 @@
       </a>
     </td>
 
-    <td data-title="Hash:">
+    <td data-title="Hash:" :title="item.hash">
       <span class="monospace md:inline-block">
         {{ item.hash }}
       </span>
     </td>
 
-    <td data-title="Device:">
+    <td data-title="Device:" :title="item.device">
       <span v-if="item.device">
         <span class="monospace md:inline-block">
           {{ item.device }}
@@ -48,7 +48,7 @@
       </span>
     </td>
 
-    <td data-title="Amount (XE):" class="amount-col">
+    <td data-title="Amount (XE):" class="amount-col" :title="formattedAmount">
       <span class="monospace">{{ formattedAmount }}</span>
     </td>
 

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -14,12 +14,12 @@
       </span>
     </td>
 
-    <td data-title="Device:" :title="item.device">
-      <span v-if="item.device" class="md:inline-block">
-        <span class="monospace">
+    <td data-title="Node:" :title="item.device">
+      <a v-if="item.device" :href="explorerNodeUrl">
+        <span class="monospace md:inline-block">
           {{ item.device }}
         </span>
-      </span>
+      </a>
       <span v-else class="text-gray-400 md:inline-block">None</span>
     </td>
 
@@ -66,7 +66,6 @@
 
 <script>
 /*global process*/
-
 import { formatXe } from '@edge/wallet-utils'
 import { ArrowCircleDownIcon, CheckCircleIcon, ClockIcon, DotsCircleHorizontalIcon } from '@heroicons/vue/outline'
 
@@ -87,6 +86,9 @@ export default {
     },
     address () {
       return this.item.tx.recipient
+    },
+    explorerNodeUrl() {
+      return `${process.env.VUE_APP_EXPLORER_URL}/node/${this.item.device}`
     },
     explorerStakeUrl() {
       return `${process.env.VUE_APP_EXPLORER_URL}/stake/${this.item.id}`

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -15,41 +15,41 @@
     </td>
 
     <td data-title="Device:" :title="item.device">
-      <span v-if="item.device">
-        <span class="monospace md:inline-block">
+      <span v-if="item.device" class="md:inline-block">
+        <span class="monospace">
           {{ item.device }}
         </span>
       </span>
-      <span v-else class="text-gray-400">None</span>
+      <span v-else class="text-gray-400 md:inline-block">None</span>
     </td>
 
     <td data-title="Type:">
-      <span class="monospace lg:font-sans">{{ formattedType }}</span>
+      <span class="md:inline-block"><span class="monospace lg:font-sans">{{ formattedType }}</span></span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="item.released">
+      <span v-if="item.released" class="md:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ArrowCircleDownIcon/></span>
         <span class="monospace lg:font-sans">Released</span>
       </span>
       <span v-else-if="item.unlockRequested">
-        <span v-if="isUnlocking">
+        <span v-if="isUnlocking" class="md:inline-block">
           <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
           <span class="monospace lg:font-sans">Unlocking</span>
         </span>
-        <span v-else>
+        <span v-else class="md:inline-block">
           <span class="mr-1 -mt-2 icon icon-grey"><DotsCircleHorizontalIcon/></span>
           <span class="monospace lg:font-sans">Unlocked</span>
         </span>
       </span>
-      <span v-else>
+      <span v-else class="md:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon/></span>
         <span class="monospace lg:font-sans">Active</span>
       </span>
     </td>
 
     <td data-title="Amount (XE):" class="amount-col" :title="formattedAmount">
-      <span class="monospace">{{ formattedAmount }}</span>
+      <span class="monospace md:inline-block">{{ formattedAmount }}</span>
     </td>
 
     <td data-title="">
@@ -115,7 +115,7 @@ export default {
 
 <style scoped>
 td {
-  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-none;
+  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-tight;
 }
 
 td span {
@@ -152,7 +152,7 @@ td .icon-grey {
 }
 
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
 button.table-button {
@@ -161,7 +161,7 @@ button.table-button {
 
 @screen lg {
   td {
-    @apply border-gray-200 pt-13 pb-15 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
   }
 
   td:first-child {
@@ -173,7 +173,7 @@ button.table-button {
   }
 
   td:last-child {
-    @apply pb-13 border-b-2;
+    @apply pb-10 border-b-2;
   }
 
   td:before {

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -24,27 +24,27 @@
     </td>
 
     <td data-title="Type:">
-      <span class="monospace md:font-sans">{{ formattedType }}</span>
+      <span class="monospace lg:font-sans">{{ formattedType }}</span>
     </td>
 
     <td data-title="Status:">
       <span v-if="item.released">
         <span class="mr-1 -mt-2 icon icon-grey"><ArrowCircleDownIcon/></span>
-        <span class="monospace md:font-sans">Released</span>
+        <span class="monospace lg:font-sans">Released</span>
       </span>
       <span v-else-if="item.unlockRequested">
         <span v-if="isUnlocking">
           <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
-          <span class="monospace md:font-sans">Unlocking</span>
+          <span class="monospace lg:font-sans">Unlocking</span>
         </span>
         <span v-else>
           <span class="mr-1 -mt-2 icon icon-grey"><DotsCircleHorizontalIcon/></span>
-          <span class="monospace md:font-sans">Unlocked</span>
+          <span class="monospace lg:font-sans">Unlocked</span>
         </span>
       </span>
       <span v-else>
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon/></span>
-        <span class="monospace md:font-sans">Active</span>
+        <span class="monospace lg:font-sans">Active</span>
       </span>
     </td>
 

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -2,54 +2,54 @@
   <tr>
     <td data-title="ID:" :title="item.id">
       <a :href="explorerStakeUrl" target="_blank" rel="noreferrer">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.id }}
         </span>
       </a>
     </td>
 
     <td data-title="Hash:" :title="item.hash">
-      <span class="monospace md:inline-block">
+      <span class="monospace lg:inline-block">
         {{ item.hash }}
       </span>
     </td>
 
     <td data-title="Node:" :title="item.device">
       <a v-if="item.device" :href="explorerNodeUrl">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.device }}
         </span>
       </a>
-      <span v-else class="text-gray-400 md:inline-block">None</span>
+      <span v-else class="text-gray-400 lg:inline-block">None</span>
     </td>
 
     <td data-title="Type:">
-      <span class="md:inline-block"><span class="monospace lg:font-sans">{{ formattedType }}</span></span>
+      <span class="lg:inline-block"><span class="monospace lg:font-sans">{{ formattedType }}</span></span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="item.released" class="md:inline-block">
+      <span v-if="item.released" class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ArrowCircleDownIcon/></span>
         <span class="monospace lg:font-sans">Released</span>
       </span>
       <span v-else-if="item.unlockRequested">
-        <span v-if="isUnlocking" class="md:inline-block">
+        <span v-if="isUnlocking" class="lg:inline-block">
           <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
           <span class="monospace lg:font-sans">Unlocking</span>
         </span>
-        <span v-else class="md:inline-block">
+        <span v-else class="lg:inline-block">
           <span class="mr-1 -mt-2 icon icon-grey"><DotsCircleHorizontalIcon/></span>
           <span class="monospace lg:font-sans">Unlocked</span>
         </span>
       </span>
-      <span v-else class="md:inline-block">
+      <span v-else class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon/></span>
         <span class="monospace lg:font-sans">Active</span>
       </span>
     </td>
 
     <td data-title="Amount (XE):" class="amount-col" :title="formattedAmount">
-      <span class="monospace md:inline-block">{{ formattedAmount }}</span>
+      <span class="monospace lg:inline-block">{{ formattedAmount }}</span>
     </td>
 
     <td data-title="">

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -14,21 +14,21 @@
       </a>
     </td>
 
-    <td v-if="sent" data-title="To:" :title="item.recipient">
-      <span class="icon-wrap">
-        <span class="mr-1 -mt-2 icon icon-red"><ArrowUpIcon /></span>
+    <td v-if="sent" data-title="To:" class="from-to" :title="item.recipient">
+      <span>
+        <span class="icon-wrap"><ArrowUpIcon class="icon inline-icon icon-red" /></span>
         <a :href="explorerToAddressUrl" target="_blank" rel="noreferrer">
-          <span class="monospace md:inline-block">
+          <span class="monospace lg:inline-block">
             {{ item.recipient }}
           </span>
         </a>
       </span>
     </td>
-    <td v-else data-title="From:" :title="item.sender">
-      <span class="icon-wrap">
-        <span class="mr-1 -mt-2 icon icon-green"><ArrowDownIcon /></span>
+    <td v-else data-title="From:" class="from-to" :title="item.sender">
+      <span>
+        <span class="icon-wrap"><ArrowDownIcon class="icon inline-icon icon-red" /></span>
         <a :href="explorerFromAddressUrl" target="_blank" rel="noreferrer">
-          <span class="monospace md:inline-block">
+          <span class="monospace lg:inline-block">
             {{ item.sender }}
           </span>
         </a>
@@ -113,7 +113,7 @@ export default {
 
 <style scoped>
 td {
-  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-none;
+  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-tight;
 }
 
 td span {
@@ -122,10 +122,6 @@ td span {
 
 td a {
   @apply overflow-ellipsis overflow-hidden whitespace-nowrap
-}
-
-.icon-wrap {
-  @apply flex overflow-ellipsis overflow-hidden whitespace-nowrap
 }
 
 td::before {
@@ -145,6 +141,10 @@ td .icon {
   @apply w-15 inline-block align-middle;
 }
 
+td .inline-icon {
+  @apply inline-block mb-2 lg:mb-0
+}
+
 td .icon-green {
   @apply text-green;
 }
@@ -158,7 +158,7 @@ td .icon-red {
 }
 
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
 tr.pending {
@@ -169,9 +169,17 @@ tr.pending a {
   @apply italic text-gray-400
 }
 
+td.from-to span {
+  @apply lg:w-11/12;
+}
+
+.icon-wrap {
+  @apply max-w-max
+}
+
 @screen lg {
   td {
-    @apply border-gray-200 pt-13 pb-15 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
   }
 
   td:first-child {
@@ -183,7 +191,7 @@ tr.pending a {
   }
 
   td:last-child {
-    @apply pr-30 pb-13 text-right border-b-2;
+    @apply pr-30 pb-10 text-right border-b-2;
   }
 
   td:before {

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -1,14 +1,14 @@
 <template>
   <tr :class="item.pending && 'pending'">
     <td data-title="Date:">
-      <span class="monospace lg:font-sans md:inline-block">
+      <span class="monospace lg:font-sans lg:inline-block">
         {{ date }}
       </span>
     </td>
 
     <td data-title="Tx Hash:" :title="item.hash">
       <a :href="explorerTxUrl" target="_blank" rel="noreferrer">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.hash }}
         </span>
       </a>

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -1,7 +1,7 @@
 <template>
   <tr :class="item.pending && 'pending'">
     <td data-title="Date:">
-      <span class="md:inline-block">
+      <span class="monospace lg:font-sans md:inline-block">
         {{ date }}
       </span>
     </td>
@@ -36,7 +36,7 @@
     </td>
 
     <td data-title="Memo:" :title="item.data.memo || 'None'">
-      <span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray'">
+      <span class="monospace lg:font-sans" :class="!item.data.memo && 'text-gray'">
         {{ item.data.memo || 'None' }}
       </span>
     </td>
@@ -44,13 +44,11 @@
   <td data-title="Status:">
       <span v-if="isConfirmed">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon /></span>
-        <span
-          class="monospace md:font-sans">{{ statusFormatted }}</span>
+        <span class="monospace lg:font-sans">{{ statusFormatted }}</span>
       </span>
       <span v-else>
         <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
-        <span
-          class="monospace md:font-sans text-gray-400">{{ statusFormatted }}</span>
+        <span class="monospace lg:font-sans text-gray-400">{{ statusFormatted }}</span>
       </span>
     </td>
 
@@ -59,7 +57,6 @@
         {{ `${sent ? '-' : ''}${formattedAmount}` }}
       </span>
     </td>
-
   </tr>
 </template>
 

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -14,7 +14,7 @@
       </a>
     </td>
 
-    <td v-if="sent" data-title="To:">
+    <td v-if="sent" data-title="To:" :title="item.recipient">
       <span class="icon-wrap">
         <span class="mr-1 -mt-2 icon icon-red"><ArrowUpIcon /></span>
         <a :href="explorerToAddressUrl" target="_blank" rel="noreferrer">
@@ -24,7 +24,7 @@
         </a>
       </span>
     </td>
-    <td v-else data-title="From:">
+    <td v-else data-title="From:" :title="item.sender">
       <span class="icon-wrap">
         <span class="mr-1 -mt-2 icon icon-green"><ArrowDownIcon /></span>
         <a :href="explorerFromAddressUrl" target="_blank" rel="noreferrer">
@@ -35,7 +35,7 @@
       </span>
     </td>
 
-    <td data-title="Memo:">
+    <td data-title="Memo:" :title="item.data.memo || 'None'">
       <span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray'">
         {{ item.data.memo || 'None' }}
       </span>
@@ -54,7 +54,7 @@
       </span>
     </td>
 
-    <td data-title="Amount (XE):" class="amount-col">
+    <td data-title="Amount (XE):" class="amount-col" :title="`${sent ? '-' : ''}${formattedAmount}`">
       <span class="monospace">
         {{ `${sent ? '-' : ''}${formattedAmount}` }}
       </span>

--- a/src/views/Staking.vue
+++ b/src/views/Staking.vue
@@ -95,13 +95,12 @@ export default {
   },
   watch: {
     metadata() {
-      // clamp pagination to available page numbers with automatic redirection
-      if (this.currentPage > this.lastPage) this.$router.push({ name: 'Staking', query: { page: this.lastPage } })
+      if (this.lastPage > 1) {
+        const p = parseInt(this.$route.query.page) || 0
+        if (p < 1) this.$router.replace({ query: { page: 1 } })
+      }
+      if (this.currentPage > this.lastPage) this.$router.replace({ query: { page: this.lastPage } })
     }
-  },
-  mounted() {
-    const p = parseInt(this.$route.query.page) || 0
-    if (p < 1) this.$router.push({ name: 'Staking', query: { page: 1 } })
   }
 }
 </script>

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -59,13 +59,12 @@ export default {
   },
   watch: {
     metadata() {
-      // clamp pagination to available page numbers with automatic redirection
-      if (this.currentPage > this.lastPage) this.$router.push({ name: 'Transactions', query: { page: this.lastPage } })
+      if (this.lastPage > 1) {
+        const p = parseInt(this.$route.query.page) || 0
+        if (p < 1) this.$router.replace({ query: { page: 1 } })
+      }
+      if (this.currentPage > this.lastPage) this.$router.replace({ query: { page: this.lastPage } })
     }
-  },
-  mounted() {
-    const p = parseInt(this.$route.query.page) || 0
-    if (p < 1) this.$router.push({ name: 'Transactions', query: { page: 1 } })
   }
 }
 </script>


### PR DESCRIPTION
- remove page redirect to page=1 when only 1 page
- added tooltip (title) to all td that could overflow
- style tables more similar to how it has been done in Explorer after recent tweaks
- change recent blocks table to match that of Explorer
- added link from stake device column to explorer node page (and renamed column to Node)
- when table collapses at lg screen size, make sure all style changes take effect. Before some were happening at lg screen size, others at md