### PR TITLE
fix: display release fee of 0 when stake unlocked

### DIFF
--- a/src/components/stakes/ReleaseStakeModal.vue
+++ b/src/components/stakes/ReleaseStakeModal.vue
@@ -288,7 +288,8 @@ export default {
       return this.unlocksAt < this.currentTime
     },
     releaseFeeParsed() {
-      return this.stake.amount * this.vars.stake_express_release_fee / 1e6
+      if (this.isUnlocked) return 0
+      else return this.stake.amount * this.vars.stake_express_release_fee / 1e6
     },
     releasePc() {
       if (this.isUnlocked) return 0


### PR DESCRIPTION
When releasing an unlocked stake, it was displaying a fee of 25% of stake amount still. It now displays 0 if stake unlocked, or 25% if using express release