### PR TITLE
v1.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wallet",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wallet",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "GPL",
       "dependencies": {
         "@edge/bridge-utils": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallet",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Web wallet for managing XE coin",
   "private": true,
   "license": "GPL",


### PR DESCRIPTION
**Wallet v1.15.1** has been released to mainnet. This deploys a hotfix for the release stake fee that was incorrectly showing as 25% for unlocked stakes. 